### PR TITLE
Mytime tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,13 +154,11 @@ if(NOT WIN32 AND NOT DEFINED HAVE_CLOCK_GETTIME)
     endif()
     if(HAVE_CLOCK_GETTIME)
         # Check if CLOCK_MONOTONIC is available for clock_gettime().
-        check_symbol_exists(CLOCK_MONOTONIC time.h HAVE_DECL_CLOCK_MONOTONIC)
+        check_symbol_exists(CLOCK_MONOTONIC time.h HAVE_CLOCK_MONOTONIC)
 
-        # HAVE_DECL_CLOCK_MONOTONIC should always be defined to 0 or 1
-        # when clock_gettime is available.
         add_compile_definitions(
             HAVE_CLOCK_GETTIME
-            HAVE_DECL_CLOCK_MONOTONIC=$<BOOL:"${HAVE_DECL_CLOCK_MONOTONIC}">
+            HAVE_CLOCK_MONOTONIC
         )
     endif()
 endif()
@@ -184,7 +182,7 @@ else()
     add_compile_definitions(MYTHREAD_POSIX)
 
     # Check if pthread_condattr_setclock() exists to use CLOCK_MONOTONIC.
-    if(HAVE_DECL_CLOCK_MONOTONIC)
+    if(HAVE_CLOCK_MONOTONIC)
         list(INSERT CMAKE_REQUIRED_LIBRARIES 0 "${CMAKE_THREAD_LIBS_INIT}")
         check_symbol_exists(pthread_condattr_setclock pthread.h
                             HAVE_PTHREAD_CONDATTR_SETCLOCK)

--- a/configure.ac
+++ b/configure.ac
@@ -638,7 +638,10 @@ case $enable_threads in
 		CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
 		AC_SEARCH_LIBS([clock_gettime], [rt])
 		AC_CHECK_FUNCS([clock_gettime pthread_condattr_setclock])
-		AC_CHECK_DECLS([CLOCK_MONOTONIC], [], [], [[#include <time.h>]])
+		AC_CHECK_DECL([CLOCK_MONOTONIC], [AC_DEFINE(
+			[HAVE_CLOCK_MONOTONIC], [1], [Define to 1 if
+			CLOCK_MONOTONIC is declared in <time.h>])], [],
+			[[#include <time.h>]])
 		CFLAGS=$OLD_CFLAGS
 		;;
 	win95)

--- a/src/common/mythread.h
+++ b/src/common/mythread.h
@@ -219,8 +219,8 @@ static inline int
 mythread_cond_init(mythread_cond *mycond)
 {
 #ifdef HAVE_CLOCK_GETTIME
-	// NOTE: HAVE_DECL_CLOCK_MONOTONIC is always defined to 0 or 1.
-#	if defined(HAVE_PTHREAD_CONDATTR_SETCLOCK) && HAVE_DECL_CLOCK_MONOTONIC
+#	if defined(HAVE_PTHREAD_CONDATTR_SETCLOCK) && \
+		defined(HAVE_CLOCK_MONOTONIC)
 	struct timespec ts;
 	pthread_condattr_t condattr;
 

--- a/src/common/mythread.h
+++ b/src/common/mythread.h
@@ -100,11 +100,17 @@ mythread_sigmask(int how, const sigset_t *restrict set,
 // Using pthreads //
 ////////////////////
 
-#include <sys/time.h>
 #include <pthread.h>
 #include <signal.h>
 #include <time.h>
 #include <errno.h>
+
+// If clock_gettime() isn't available, use gettimeofday() from <sys/time.h>
+// as a fallback. gettimeofday() is in SUSv2 and thus is supported on all
+// relevant POSIX systems.
+#if !defined(HAVE_CLOCK_GETTIME)
+#	include <sys/time.h>
+#endif
 
 #define MYTHREAD_RET_TYPE void *
 #define MYTHREAD_RET_VALUE NULL

--- a/src/xz/mytime.c
+++ b/src/xz/mytime.c
@@ -12,7 +12,9 @@
 
 #include "private.h"
 
-#if !(defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC))
+#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC)
+#	include <time.h>
+#else
 #	include <sys/time.h>
 #endif
 

--- a/src/xz/mytime.c
+++ b/src/xz/mytime.c
@@ -12,7 +12,7 @@
 
 #include "private.h"
 
-#if !(defined(HAVE_CLOCK_GETTIME) && HAVE_DECL_CLOCK_MONOTONIC)
+#if !(defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC))
 #	include <sys/time.h>
 #endif
 
@@ -28,8 +28,7 @@ static uint64_t next_flush;
 static uint64_t
 mytime_now(void)
 {
-	// NOTE: HAVE_DECL_CLOCK_MONOTONIC is always defined to 0 or 1.
-#if defined(HAVE_CLOCK_GETTIME) && HAVE_DECL_CLOCK_MONOTONIC
+#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_MONOTONIC)
 	// If CLOCK_MONOTONIC was available at compile time but for some
 	// reason isn't at runtime, fallback to CLOCK_REALTIME which
 	// according to POSIX is mandatory for all implementations.


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [X] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
mytime.c requires mythread.h to include <time.h> if POSIX threads are enabled. Also, HAVE_DECL_CLOCK_MONOTONIC is always set to 0 or 1

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->
-  mytime.c conditionally includes either <time.h> or <sys/time.h>, depending on the configuration.
- HAVE_DECL_CLOCK_MONOTONIC is now only set if it is set to 1 in both autotools and CMake.
- mythread.h will always include <time.h>, but conditionally includes <sys/time.h> now.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR. -->