### PR TITLE
Build: Only define HAVE_DECL_PROGRAM_INVOCATION_NAME if it is set to 1.

### DIFF
--- a/cmake/tuklib_progname.cmake
+++ b/cmake/tuklib_progname.cmake
@@ -13,7 +13,6 @@ include(CheckSymbolExists)
 function(tuklib_progname TARGET_OR_ALL)
     # NOTE: This glibc extension requires _GNU_SOURCE.
     check_symbol_exists(program_invocation_name errno.h
-                        HAVE_DECL_PROGRAM_INVOCATION_NAME)
-    tuklib_add_definition_if("${TARGET_OR_ALL}"
-                             HAVE_DECL_PROGRAM_INVOCATION_NAME)
+                        HAVE_PROGRAM_INVOCATION_NAME)
+    tuklib_add_definition_if("${TARGET_OR_ALL}" HAVE_PROGRAM_INVOCATION_NAME)
 endfunction()

--- a/m4/tuklib_progname.m4
+++ b/m4/tuklib_progname.m4
@@ -21,5 +21,8 @@
 
 AC_DEFUN_ONCE([TUKLIB_PROGNAME], [
 AC_REQUIRE([TUKLIB_COMMON])
-AC_CHECK_DECLS([program_invocation_name], [], [], [#include <errno.h>])
+AC_CHECK_DECL([program_invocation_name], [AC_DEFINE(
+	[HAVE_PROGRAM_INVOCATION_NAME], [1],
+	[Define to 1 if PROGRAM_INVOCATION_NAME is declared in <errno.h>])],
+	[], [#include <errno.h>])
 ])dnl

--- a/src/common/tuklib_progname.c
+++ b/src/common/tuklib_progname.c
@@ -14,7 +14,7 @@
 #include <string.h>
 
 
-#if !HAVE_DECL_PROGRAM_INVOCATION_NAME
+#ifndef HAVE_PROGRAM_INVOCATION_NAME
 char *progname = NULL;
 #endif
 

--- a/src/common/tuklib_progname.h
+++ b/src/common/tuklib_progname.h
@@ -18,7 +18,7 @@
 
 TUKLIB_DECLS_BEGIN
 
-#if HAVE_DECL_PROGRAM_INVOCATION_NAME
+#ifdef HAVE_PROGRAM_INVOCATION_NAME
 #	define progname program_invocation_name
 #else
 #	define progname TUKLIB_SYMBOL(tuklib_progname)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [X] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
HAVE_DECL_PROGRAM_INVOCATION_NAME macro definition is inconsistent across build systems and is always defined, even if set to 0.

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->
- HAVE_DECL_PROGRAM_INVOCATION_NAME -> HAVE_PROGRAM_INVOCATION_NAME
- Consistent across all build systems
- HAVE_PROGRAM_INVOCATION_NAME is only defined when set to 1

## Does this introduce a breaking change?

- [ ] Yes
- [X No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR. -->