### PR TITLE
Tests: Replace non portable shell parameter expansion

### DIFF
--- a/tests/create_compress_files.c
+++ b/tests/create_compress_files.c
@@ -24,7 +24,7 @@
 // Avoid re-creating the test files every time the tests are run.
 #define maybe_create_test(argc, argv, name) \
 do { \
-	if ((argc < 2 || strcmp(argv[1], #name) == 0) \
+	if ((argc < 2 || strcmp(argv[1], "compress_generated_" #name) == 0) \
 			&& !file_exists("compress_generated_" #name)) { \
 		FILE *file = file_create("compress_generated_" #name); \
 		write_ ## name(file); \

--- a/tests/test_compress.sh
+++ b/tests/test_compress.sh
@@ -85,9 +85,16 @@ test -x ../src/xzdec/xzdec || XZDEC=
 
 # Create the required input file if needed.
 FILE=$1
+# Derive temporary filenames for compressed and uncompressed outputs
+# from the input filename. This is needed when multiple tests are
+# run in parallel.
+TMP_COMP="tmp_comp_$FILE"
+TMP_UNCOMP="tmp_uncomp_$FILE"
 case $FILE in
+#	compress_generated files will be created in the build directory
+#	in the /tests/ sub-directory.
 	compress_generated_*)
-		if ./create_compress_files "${FILE#compress_generated_}" ; then
+		if ./create_compress_files "$FILE" ; then
 			:
 		else
 			rm -f "$FILE"
@@ -95,17 +102,16 @@ case $FILE in
 			exit 1
 		fi
 		;;
+#	compress_prepared files exist in the source directory since they
+#       do not need to be copied or regenerated.
+	compress_prepared_*)
+		FILE="$srcdir/$FILE"
+		;;
 	'')
 		echo "No test file was specified."
 		exit 1
 		;;
 esac
-
-# Derive temporary filenames for compressed and uncompressed outputs
-# from the input filename. This is needed when multiple tests are
-# run in parallel.
-TMP_COMP="tmp_comp_${FILE##*/}"
-TMP_UNCOMP="tmp_uncomp_${FILE##*/}"
 
 # Remove temporary now (in case they are something weird), and on exit.
 rm -f "$TMP_COMP" "$TMP_UNCOMP"

--- a/tests/test_compress_prepared_bcj_sparc
+++ b/tests/test_compress_prepared_bcj_sparc
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec "$srcdir/test_compress.sh" "$srcdir/compress_prepared_bcj_sparc"
+exec "$srcdir/test_compress.sh" compress_prepared_bcj_sparc

--- a/tests/test_compress_prepared_bcj_x86
+++ b/tests/test_compress_prepared_bcj_x86
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec "$srcdir/test_compress.sh" "$srcdir/compress_prepared_bcj_x86"
+exec "$srcdir/test_compress.sh" compress_prepared_bcj_x86


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [X] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Tests fail on Solaris 10 because of non portable shell parameter expansion.

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: 
https://github.com/tukaani-project/xz/issues/10

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->
- Only effects test_compress based tests.
- Alters the create_compress_files.c to require the full filename as an argument instead of just "abc", "text", or "random.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR. -->
I tried using ${parameter:offset} instead, but dash did not support this. Shell scripting is fun...