### PR TITLE
xz: Refactor duplicated check for custom suffix when using --format=raw

### DIFF
--- a/src/xz/args.c
+++ b/src/xz/args.c
@@ -724,6 +724,14 @@ args_parse(args_info *args, int argc, char **argv)
 			&& opt_mode != MODE_LIST))
 		coder_set_compression_settings();
 
+	// If raw format is used and a custom suffix is not provided,
+	// then only stdout mode can be used when compressing or decompressing.
+	if (opt_format == FORMAT_RAW && suffix_is_set() && !opt_stdout &&
+			(opt_mode == MODE_COMPRESS ||
+			opt_mode == MODE_DECOMPRESS))
+		message_fatal(_("With --format=raw, --suffix=.SUF is "
+				"required unless writing to stdout"));
+
 	// If no filenames are given, use stdin.
 	if (argv[optind] == NULL && args->files_name == NULL) {
 		// We don't modify or free() the "-" constant. The caller

--- a/src/xz/suffix.c
+++ b/src/xz/suffix.c
@@ -131,15 +131,7 @@ uncompressed_name(const char *src_name, const size_t src_len)
 	const char *new_suffix = "";
 	size_t new_len = 0;
 
-	if (opt_format == FORMAT_RAW) {
-		// Don't check for known suffixes when --format=raw was used.
-		if (custom_suffix == NULL) {
-			message_error(_("%s: With --format=raw, "
-					"--suffix=.SUF is required unless "
-					"writing to stdout"), src_name);
-			return NULL;
-		}
-	} else {
+	if (opt_format != FORMAT_RAW) {
 		for (size_t i = 0; i < ARRAY_SIZE(suffixes); ++i) {
 			new_len = test_suffix(suffixes[i].compressed,
 					src_name, src_len);
@@ -260,15 +252,6 @@ compressed_name(const char *src_name, size_t src_len)
 			msg_suffix(src_name, custom_suffix);
 			return NULL;
 		}
-	}
-
-	// TODO: Hmm, maybe it would be better to validate this in args.c,
-	// since the suffix handling when decoding is weird now.
-	if (opt_format == FORMAT_RAW && custom_suffix == NULL) {
-		message_error(_("%s: With --format=raw, "
-				"--suffix=.SUF is required unless "
-				"writing to stdout"), src_name);
-		return NULL;
 	}
 
 	const char *suffix = custom_suffix != NULL
@@ -408,4 +391,11 @@ suffix_set(const char *suffix)
 	free(custom_suffix);
 	custom_suffix = xstrdup(suffix);
 	return;
+}
+
+
+extern bool
+suffix_is_set(void)
+{
+	return custom_suffix == NULL;
 }

--- a/src/xz/suffix.h
+++ b/src/xz/suffix.h
@@ -26,3 +26,10 @@ extern char *suffix_get_dest_name(const char *src_name);
 /// suffix, thus if this is called multiple times, the old suffixes are freed
 /// and forgotten.
 extern void suffix_set(const char *suffix);
+
+/// \brief      Check if a custom suffix has been set
+///
+/// Returns true if the internal tracking of the suffix string has been set
+/// and false if the string has not been set. This will keep the suffix
+/// string encapsulated instead of extern-ing the variable.
+extern bool suffix_is_set(void);


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [X] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
There were duplicated checks for a custom suffix set when using --format=raw in both the encoder and decoder.

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->
- The check is now done when parsing arguments

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR. -->