### PR TITLE
xz: Fix warning -Wformat-nonliteral on clang in message.c.

### DIFF
--- a/src/xz/message.c
+++ b/src/xz/message.c
@@ -723,7 +723,16 @@ vmessage(enum message_verbosity v, const char *fmt, va_list ap)
 		// This is a translatable string because French needs
 		// a space before a colon.
 		fprintf(stderr, _("%s: "), progname);
+
+#ifdef __clang__
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
 		vfprintf(stderr, fmt, ap);
+#ifdef __clang__
+#	pragma GCC diagnostic pop
+#endif
+
 		fputc('\n', stderr);
 
 		signals_unblock();


### PR DESCRIPTION
clang and gcc differ in how they handle -Wformat-nonliteral. gcc will allow a non-literal format string as long as the function takes its format arguments as a va_list.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [X] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe): Disable a clang warning


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR. -->