### PR TITLE
liblzma: Change use of LZMA_STR_NO_VALIDATION in lzma_str_to_filters().

### DIFF
--- a/src/liblzma/api/lzma/filter.h
+++ b/src/liblzma/api/lzma/filter.h
@@ -476,7 +476,9 @@ extern LZMA_API(lzma_ret) lzma_filter_flags_decode(
  * By default lzma_str_to_filters() can return an error if the filter chain
  * as a whole isn't usable in the .xz format or in the raw encoder or decoder.
  * With this flag the validation is skipped (this doesn't affect the handling
- * of the individual filter options).
+ * of the individual filter options). This flag will also allow filters not
+ * supported by the .xz format, so also using LZMA_STR_ALL_FILTERS
+ * is not needed.
  */
 #define LZMA_STR_NO_VALIDATION  UINT32_C(0x02)
 

--- a/src/liblzma/common/string_conversion.c
+++ b/src/liblzma/common/string_conversion.c
@@ -913,7 +913,8 @@ str_to_filters(const char **const str, lzma_filter *filters, uint32_t flags,
 	//
 	// If LZMA_STR_ALL_FILTERS isn't used we allow only filters that
 	// can be used in .xz.
-	const bool only_xz = (flags & LZMA_STR_ALL_FILTERS) == 0;
+	const bool only_xz = (flags & (LZMA_STR_ALL_FILTERS
+			| LZMA_STR_NO_VALIDATION)) == 0;
 
 	// Use a temporary array so that we don't modify the caller-supplied
 	// one until we know that no errors occurred.


### PR DESCRIPTION
The LZMA_STR_NO_VALIDATION flag name and description is ambiguous to how it handles individual filters that cannot be used in .xz format (only lzma1 for now). Now LZMA_STR_NO_VALIDATION is a super set of the LZMA_STR_ALL_FILTERS flag, so they don't need to be used together.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [X] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe): 

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: https://github.com/tukaani-project/xz/issues/24


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->
- LZMA_STR_NO_VALIDATION is now a superset of LZMA_STR_ALL_FILTERS in lzma_str_to_filters()

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information
This is another option instead of https://github.com/tukaani-project/xz/pull/25. This is a behavior change for an API function, so it would have to be announced properly in the next release.