### PR TITLE
Detect symver attribute support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -791,6 +791,15 @@ else
 				time with Libtool if neither --with-pic nor
 				--without-pic is used). This define must be
 				used together with liblzma_linux.map.])
+			OLD_CFLAGS="$CFLAGS"
+			CFLAGS="$CFLAGS -Werror"  # we need -Werror to make sure the attribute is not ignored
+			AC_COMPILE_IFELSE([AC_LANG_SOURCE(
+				[__attribute__ ((symver ("test@TEST"))) void foo(void) { }
+				])],
+				[AC_DEFINE([HAVE_SYMVER_ATTRIBUTE], [1],
+					[Define to 1 if GCC supports the symver attribute])],
+				[])
+			CFLAGS="$OLD_CFLAGS"
 			;;
 		*)
 			enable_symbol_versions=generic

--- a/src/liblzma/common/common.h
+++ b/src/liblzma/common/common.h
@@ -76,7 +76,7 @@
 // too (which doesn't support __symver__) so use it to detect if __symver__
 // is available. This should be far more reliable than looking at compiler
 // version macros as nowadays especially __GNUC__ is defined by many compilers.
-#	if lzma_has_attribute(__symver__)
+#	if defined(HAVE_SYMVER_ATTRIBUTE)
 #		define LZMA_SYMVER_API(extnamever, type, intname) \
 			extern __attribute__((__symver__(extnamever))) \
 					LZMA_API(type) intname


### PR DESCRIPTION
On Microblaze builds will fail when trying to add symver information because  `__attribute__((symver ..))` is not supported even though `__has_attribute(__symver__)` returns true.

Support for symver needs to be detected via a compile test since `__has_attribute` can report false positives [0].

Add a configure compile check for `__attribute__((symver ..))` to ensure it is supported and define a variable to advertise support.

[0] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101766#c1

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and without warnings or errors
- [ ] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
builds targeting the microblaze fail

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->

- Builds now succeed

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information

I tested compiles via GCC 12 and 9 for x86_64 and microblaze targets and didn't encounter issues.

<!-- Any other information that is important to this PR. -->