### PR TITLE
lzma_lzma_preset() return failure with unsupported Match Finder

### DIFF
--- a/src/liblzma/lzma/lzma_encoder_presets.c
+++ b/src/liblzma/lzma/lzma_encoder_presets.c
@@ -60,5 +60,18 @@ lzma_lzma_preset(lzma_options_lzma *options, uint32_t preset)
 		}
 	}
 
+#ifndef HAVE_MF_HC3
+	if (options->mf == LZMA_MF_HC3)
+		return true;
+#endif
+#ifndef HAVE_MF_HC4
+	if (options->mf == LZMA_MF_HC4)
+		return true;
+#endif
+#ifndef HAVE_MF_BT4
+	if (options->mf == LZMA_MF_BT4)
+		return true;
+#endif
+
 	return false;
 }

--- a/tests/test_bcj_exact_size.c
+++ b/tests/test_bcj_exact_size.c
@@ -41,7 +41,9 @@ test_exact_size(void)
 	// it has fixed 4-byte alignment which makes triggering the potential
 	// bug easy.
 	lzma_options_lzma opt_lzma2;
-	assert_false(lzma_lzma_preset(&opt_lzma2, 0));
+	if (lzma_lzma_preset(&opt_lzma2, 0))
+		assert_skip("Preset 0 is not supported by this liblzma "
+				"configuration.");
 
 	lzma_filter filters[3] = {
 		{ .id = LZMA_FILTER_POWERPC, .options = NULL },

--- a/tests/test_block_header.c
+++ b/tests/test_block_header.c
@@ -166,36 +166,37 @@ test_lzma_block_header_size(void)
 	// because the size of the LZMA2 properties is known by liblzma
 	// without reading any of the options so it doesn't validate them.
 	lzma_options_lzma bad_ops;
-	assert_false(lzma_lzma_preset(&bad_ops, 1));
-	bad_ops.pb = 0x1000;
+	if (!lzma_lzma_preset(&bad_ops, 1)) {
+		bad_ops.pb = 0x1000;
 
-	lzma_filter bad_filters[2] = {
-		{
-			.id = LZMA_FILTER_LZMA2,
-			.options = &bad_ops
-		},
-		{
-			.id = LZMA_VLI_UNKNOWN,
-			.options = NULL
-		}
-	};
+		lzma_filter bad_filters[2] = {
+			{
+				.id = LZMA_FILTER_LZMA2,
+				.options = &bad_ops
+			},
+			{
+				.id = LZMA_VLI_UNKNOWN,
+				.options = NULL
+			}
+		};
 
-	block.filters = bad_filters;
+		block.filters = bad_filters;
 
-	assert_lzma_ret(lzma_block_header_size(&block), LZMA_OK);
-	assert_uint(block.header_size, >=, LZMA_BLOCK_HEADER_SIZE_MIN);
-	assert_uint(block.header_size, <=, LZMA_BLOCK_HEADER_SIZE_MAX);
-	assert_uint_eq(block.header_size % 4, 0);
+		assert_lzma_ret(lzma_block_header_size(&block), LZMA_OK);
+		assert_uint(block.header_size, >=, LZMA_BLOCK_HEADER_SIZE_MIN);
+		assert_uint(block.header_size, <=, LZMA_BLOCK_HEADER_SIZE_MAX);
+		assert_uint_eq(block.header_size % 4, 0);
 
-	// Use an invalid block option. The check type isn't stored in
-	// the Block Header and so _header_size ignores it.
-	block.check = INVALID_LZMA_CHECK_ID;
-	block.ignore_check = false;
+		// Use an invalid block option. The check type isn't stored in
+		// the Block Header and so _header_size ignores it.
+		block.check = INVALID_LZMA_CHECK_ID;
+		block.ignore_check = false;
 
-	assert_lzma_ret(lzma_block_header_size(&block), LZMA_OK);
-	assert_uint(block.header_size, >=, LZMA_BLOCK_HEADER_SIZE_MIN);
-	assert_uint(block.header_size, <=, LZMA_BLOCK_HEADER_SIZE_MAX);
-	assert_uint_eq(block.header_size % 4, 0);
+		assert_lzma_ret(lzma_block_header_size(&block), LZMA_OK);
+		assert_uint(block.header_size, >=, LZMA_BLOCK_HEADER_SIZE_MIN);
+		assert_uint(block.header_size, <=, LZMA_BLOCK_HEADER_SIZE_MAX);
+		assert_uint_eq(block.header_size % 4, 0);
+	}
 #endif
 }
 
@@ -504,7 +505,8 @@ main(int argc, char **argv)
 	tuktest_start(argc, argv);
 
 	if (lzma_lzma_preset(&opt_lzma, 1))
-		tuktest_error("lzma_lzma_preset() failed");
+		tuktest_early_skip("Preset 1 is not supported by this "
+				"liblzma configuration.");
 
 	tuktest_run(test_lzma_block_header_size);
 	tuktest_run(test_lzma_block_header_encode);

--- a/tests/test_compress.sh
+++ b/tests/test_compress.sh
@@ -28,6 +28,18 @@ else
 	exit 77
 fi
 
+# xz compression tests are used with presets 1-4.
+# Presets 1-3 require LZMA_MF_HC4, and preset 4 requires LZMA_MF_BT4.
+# The preset levels are subject to change, so this will need to be updated
+# if the presets match finder requirements change.
+if grep 'define HAVE_MF_HC4' ../config.h > /dev/null \
+		&& grep 'define HAVE_MF_BT4' ../config.h > /dev/null ; then
+	:
+else
+	echo "Match finder HC4 or BT4 support is disabled, skipping this test."
+	exit 77
+fi
+
 # Find out if our shell supports functions.
 eval 'unset foo ; foo() { return 42; } ; foo'
 if test $? != 42 ; then

--- a/tests/test_filter_flags.c
+++ b/tests/test_filter_flags.c
@@ -500,14 +500,20 @@ main(int argc, char **argv)
 	if (lzma_filter_encoder_is_supported(LZMA_FILTER_LZMA1)) {
 		lzma_options_lzma *options = tuktest_malloc(
 				sizeof(lzma_options_lzma));
-		lzma_lzma_preset(options, LZMA_PRESET_DEFAULT);
+		if (lzma_lzma_preset(options, LZMA_PRESET_DEFAULT))
+			tuktest_early_skip("Preset %d is not supported by "
+					"this liblzma configuration.",
+					LZMA_PRESET_DEFAULT);
 		lzma1_filter.options = options;
 	}
 
 	if (lzma_filter_encoder_is_supported(LZMA_FILTER_LZMA2)) {
 		lzma_options_lzma *options = tuktest_malloc(
 				sizeof(lzma_options_lzma));
-		lzma_lzma_preset(options, LZMA_PRESET_DEFAULT);
+		if (lzma_lzma_preset(options, LZMA_PRESET_DEFAULT))
+			tuktest_early_skip("Preset %d is not supported by "
+					"this liblzma configuration.",
+					LZMA_PRESET_DEFAULT);
 		lzma2_filter.options = options;
 	}
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [X] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
lzma_lzma_preset() will return success, even if the preset is unusable with the liblzma build.

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: fixes https://github.com/tukaani-project/xz/issues/37


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->
- lzma_lzma_preset() will check if match finder is supported.
- Tests were updated to skip or pass if the requested preset is not usable.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information
Alternatively, this could be solved with a documentation change if we want to explicitly say that lzma_lzma_preset() does not guarantee that the preset is usable. Based on the current documentation, it seems that lzma_lzma_preset() should only return success if the preset is usable.
