### PR TITLE
liblzma: Clarify lzma_lzma_preset() documentation in lzma12.h.

### DIFF
--- a/src/liblzma/api/lzma/lzma12.h
+++ b/src/liblzma/api/lzma/lzma12.h
@@ -555,6 +555,11 @@ do { \
  * This function is available only if LZMA1 or LZMA2 encoder has been enabled
  * when building liblzma.
  *
+ * If features (like certain match finders) have been disabled at build time,
+ * then the function may return success (false) even though the resulting
+ * LZMA1/LZMA2 options may not be usable for encoder initialization
+ * (LZMA_OPTIONS_ERROR).
+ *
  * \param[out]  options Pointer to LZMA1 or LZMA2 options to be filled
  * \param       preset  Preset level bitwse-ORed with preset flags
  *


### PR DESCRIPTION
lzma_lzma_preset() does not guarentee that the lzma_options_lzma are usable in an encoder even if it returns false (success). If liblzma is built with default configurations, then the options will always be usable. However if the match finders hc3, hc4, or bt4 are disabled, then the options may not be usable depending on the preset level requested.

The documentation was updated to reflect this complexity, since this behavior was unclear before.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [ ] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe): 

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: fixes https://github.com/tukaani-project/xz/issues/37

## Does this introduce a breaking change?

- [ ] Yes
- [X] No