### PR TITLE
xz: Improve compatibility with systems without capability mode support

### DIFF
--- a/src/xz/file_io.c
+++ b/src/xz/file_io.c
@@ -193,23 +193,24 @@ io_sandbox_enter(int src_fd)
 	cap_rights_t rights;
 
 	if (cap_rights_limit(src_fd, cap_rights_init(&rights,
-			CAP_EVENT, CAP_FCNTL, CAP_LOOKUP, CAP_READ, CAP_SEEK)))
+			CAP_EVENT, CAP_FCNTL, CAP_LOOKUP, CAP_READ, CAP_SEEK)) < 0 &&
+	    errno != ENOSYS)
 		goto error;
 
 	if (cap_rights_limit(STDOUT_FILENO, cap_rights_init(&rights,
 			CAP_EVENT, CAP_FCNTL, CAP_FSTAT, CAP_LOOKUP,
-			CAP_WRITE, CAP_SEEK)))
+			CAP_WRITE, CAP_SEEK)) < 0 && errno != ENOSYS)
 		goto error;
 
 	if (cap_rights_limit(user_abort_pipe[0], cap_rights_init(&rights,
-			CAP_EVENT)))
+			CAP_EVENT)) < 0 && errno != ENOSYS)
 		goto error;
 
 	if (cap_rights_limit(user_abort_pipe[1], cap_rights_init(&rights,
-			CAP_WRITE)))
+			CAP_WRITE)) < 0 && errno != ENOSYS)
 		goto error;
 
-	if (cap_enter())
+	if (cap_enter() < 0 && errno != ENOSYS)
 		goto error;
 
 #elif defined(HAVE_PLEDGE)


### PR DESCRIPTION
When the kernel is built without capability mode support, or when using an emulator like qemu-user-static that does not translate system calls, these calls will return a negative number and set the errno to ENOSYS. However, this error does not indicate a real programming or runtime error and is generally ignored by base system applications built with capability mode sandboxing.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [X] All previous and new tests pass


## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix

## What is the current behavior?

xz would abort execution with `Failed to enable the sandbox` when capability mode system calls failed, regardless if the host system have capability mode support.

It is advisable that binaries with capability mode sandbox enabled to ignore capability mode errors when they are solely because the system does not have the support, this is done on many applications including OpenSSH and base system utilities.  In fact, FreeBSD have a set of macros called [capsicum_helpers(3)](https://man.freebsd.org/cgi/man.cgi?query=capsicum_helpers&sektion=3) which [wraps](https://cgit.freebsd.org/src/tree/lib/libcapsicum/capsicum_helpers.h#n153) this anti-pattern.

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=269185


## What is the new behavior?

xz will ignore sandbox failures caused by the kernel lacking support of capsicum mode.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Other information

The proposed patch modified `cap_*` calls to also check if the failure was caused by the lack of support (ENOSYS) and make it ignore it.  If possible, it's probably reasonable to just use `caph_*` calls found in `capsicum_helpers(3)`.