### PR TITLE
protect against double find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -889,13 +889,15 @@ write_basic_package_version_file(
 set(LZMA_CONFIG_CONTENTS
 "include(\"\${CMAKE_CURRENT_LIST_DIR}/liblzma-targets.cmake\")
 
-# Be compatible with the spelling used by the FindLibLZMA module. This
-# doesn't use ALIAS because it would make CMake resolve LibLZMA::LibLZMA
-# to liblzma::liblzma instead of keeping the original spelling. Keeping
-# the original spelling is important for good FindLibLZMA compatibility.
-add_library(LibLZMA::LibLZMA INTERFACE IMPORTED)
-set_target_properties(LibLZMA::LibLZMA PROPERTIES
-                      INTERFACE_LINK_LIBRARIES liblzma::liblzma)
+if(NOT TARGET LibLZMA::LibLZMA)
+       # Be compatible with the spelling used by the FindLibLZMA module. This
+       # doesn't use ALIAS because it would make CMake resolve LibLZMA::LibLZMA
+       # to liblzma::liblzma instead of keeping the original spelling. Keeping
+       # the original spelling is important for good FindLibLZMA compatibility.
+       add_library(LibLZMA::LibLZMA INTERFACE IMPORTED)
+       set_target_properties(LibLZMA::LibLZMA PROPERTIES
+                             INTERFACE_LINK_LIBRARIES liblzma::liblzma)
+endif()
 ")
 
 if(ENABLE_THREADS STREQUAL "posix")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -890,13 +890,13 @@ set(LZMA_CONFIG_CONTENTS
 "include(\"\${CMAKE_CURRENT_LIST_DIR}/liblzma-targets.cmake\")
 
 if(NOT TARGET LibLZMA::LibLZMA)
-       # Be compatible with the spelling used by the FindLibLZMA module. This
-       # doesn't use ALIAS because it would make CMake resolve LibLZMA::LibLZMA
-       # to liblzma::liblzma instead of keeping the original spelling. Keeping
-       # the original spelling is important for good FindLibLZMA compatibility.
-       add_library(LibLZMA::LibLZMA INTERFACE IMPORTED)
-       set_target_properties(LibLZMA::LibLZMA PROPERTIES
-                             INTERFACE_LINK_LIBRARIES liblzma::liblzma)
+    # Be compatible with the spelling used by the FindLibLZMA module. This
+    # doesn't use ALIAS because it would make CMake resolve LibLZMA::LibLZMA
+    # to liblzma::liblzma instead of keeping the original spelling. Keeping
+    # the original spelling is important for good FindLibLZMA compatibility.
+    add_library(LibLZMA::LibLZMA INTERFACE IMPORTED)
+    set_target_properties(LibLZMA::LibLZMA PROPERTIES
+                          INTERFACE_LINK_LIBRARIES liblzma::liblzma)
 endif()
 ")
 


### PR DESCRIPTION
Boost iostream [uses `find_package` in quiet mode](https://github.com/boostorg/iostreams/blob/5fe4de84f863964f7573be1146f524886146a5d3/CMakeLists.txt#L16) and then [again uses `find_package` with required](https://github.com/boostorg/iostreams/blob/5fe4de84f863964f7573be1146f524886146a5d3/CMakeLists.txt#LL30C1-L30C49). This second call triggers a `add_library cannot create imported target "ZLIB::ZLIB" because another target with the same name already exists.`

This can simply be fixed by skipping the alias part on secondary `find_package` runs.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and without warnings or errors
- [x] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

From Boost iostream compilation which finds XZ via config file:

```
CMake Error at C:/Temp/lib/win_x86_64_debug/lib/cmake/zlib/ZLIBConfig.cmake:13 (add_library):
  add_library cannot create imported target "ZLIB::ZLIB" because another
  target with the same name already exists.
Call Stack (most recent call first):
  libs/iostreams/CMakeLists.txt:30 (find_package)
  libs/iostreams/CMakeLists.txt:38 (boost_iostreams_option)
```

## What is the new behavior?

`find_package` works on the first and all folloring runs.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No