### PR TITLE
tests/Makefile.am: add target of 'build-PROGRAMS'

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -76,6 +76,9 @@ if COND_SCRIPTS
 TESTS += test_scripts.sh
 endif
 
+build-PROGRAMS: all-am
+	$(MAKE) $(AM_MAKEFLAGS) $(check_PROGRAMS)
+
 clean-local:
 	-rm -f compress_generated_* \
 		xzgrep_test_output xzgrep_test_1.xz xzgrep_test_2.xz


### PR DESCRIPTION
Add target 'build-PROGRAMS' to only compile the test set under '/tests' and not run locally.
