### PR TITLE
Replaced crc64_fast constructor with ifunc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -763,6 +763,25 @@ check_c_source_compiles("
 cmake_pop_check_state()
 tuklib_add_definition_if(liblzma HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR)
 
+# Check for __attribute__((__ifunc__())) support.
+option(CHECK_ATTR_IFUNC "Use __attribute__((__ifunc__())) if supported by \
+the system" ON)
+
+if (CHECK_ATTR_IFUNC)
+    cmake_push_check_state()
+    set(CMAKE_REQUIRED_FLAGS "-Werror")
+    check_c_source_compiles("
+            static void func(void) { return; }
+            static void (*resolve_func (void)) (void) { return func; }
+            void func_ifunc (void)
+                    __attribute__ ((__ifunc__ (\"resolve_func\")));
+            int main(void) { return 0; }
+        "
+        HAVE_FUNC_ATTRIBUTE_IFUNC)
+    cmake_pop_check_state()
+    tuklib_add_definition_if(liblzma HAVE_FUNC_ATTRIBUTE_IFUNC)
+endif()
+
 # cpuid.h
 check_include_file(cpuid.h HAVE_CPUID_H)
 tuklib_add_definition_if(liblzma HAVE_CPUID_H)

--- a/configure.ac
+++ b/configure.ac
@@ -859,7 +859,35 @@ AC_COMPILE_IFELSE([
 ], [
 	AC_MSG_RESULT([no])
 ])
+
 CFLAGS="$OLD_CFLAGS"
+
+# __attribute__((__ifunc__())) can be used for one-time initializations,
+# similar to __attribute__((__constructor__)).
+AC_ARG_ENABLE([ifunc], [AS_HELP_STRING([--disable-ifunc],
+		[do not use __attribute__((__ifunc__()))])],
+	[], [enable_ifunc=yes])
+
+if test "x$enable_ifunc" = xyes ; then
+	OLD_CFLAGS="$CFLAGS"
+	CFLAGS="$CFLAGS -Werror"
+	AC_MSG_CHECKING([if __attribute__((__ifunc__())) can be used])
+	AC_COMPILE_IFELSE([
+		static void func(void) { return; }
+		static void (*resolve_func (void)) (void) { return func; }
+		void func_ifunc (void)
+				__attribute__ ((__ifunc__ ("resolve_func")));
+	], [
+		AC_DEFINE([HAVE_FUNC_ATTRIBUTE_IFUNC], [1],
+			[Define to 1 if __attribute__((__ifunc__()))
+			is supported for functions.])
+		AC_MSG_RESULT([yes])
+	], [
+		AC_MSG_RESULT([no])
+	])
+
+	CFLAGS="$OLD_CFLAGS"
+fi
 
 
 ###############################################################################


### PR DESCRIPTION
The ifunc attribute is a cleaner and marginally more performant
mechanism for dynamically choosing a routine at runtime.

The PR contains two parts:
1. The first replaces the crc64 construct with the ifunc resolver.
2. The second modifies the build process to account for the ifunc attribute.

HAVE_FUNC_ATTRIBUTE_IFUNC is set if ifuncs can be built
on the system. glibc has supported ifunc since version 2.11 (2009). Building for older machines
may want to manually disable ifunc support when building.
--disable-ifunc can be used with autotools and
USE_ATTR_IFUNC=OFF can be used with CMake to disable the check for ifunc support.
USE_ATTR_IFUNC defaults to ON for CMake and enable_ifunc defaults to yes for autotools.

More about ifuncs can be read [here](https://sourceware.org/glibc/wiki/GNU_IFUNC) or [here](https://www.agner.org/optimize/optimizing_cpp.pdf#page=142).


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [X] All previous and new tests pass


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [X] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
crc64\_fast currently uses the \_\_attribute\_\_ constructor to choose the crc implementation to use.


## What is the new behavior?
I replaced the \_\_attribute\_\_((\_\_constructor\_\_)) with \_\_attribute\_\_((ifunc())) in crc64_fast.c

- The HAVE_FUNC_ATTRIBUTE_IFUNC flag was added to configure.ac
- The USE_ATTR_IFUNC cmake option was added to CMakeLists.txt

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

Functionality should be identical.


## Other information

<!-- Any other information that is important to this PR. -->