### PR TITLE
liblzma: Support wasi-sdk with `ENABLE_THREADS=OFF` option

### DIFF
--- a/src/liblzma/common/common.h
+++ b/src/liblzma/common/common.h
@@ -14,7 +14,6 @@
 #define LZMA_COMMON_H
 
 #include "sysdefs.h"
-#include "mythread.h"
 #include "tuklib_integer.h"
 
 #if defined(_WIN32) || defined(__CYGWIN__)

--- a/src/liblzma/common/stream_decoder_mt.c
+++ b/src/liblzma/common/stream_decoder_mt.c
@@ -11,6 +11,7 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "mythread.h"
 #include "common.h"
 #include "block_decoder.h"
 #include "stream_decoder.h"

--- a/src/liblzma/common/stream_encoder_mt.c
+++ b/src/liblzma/common/stream_encoder_mt.c
@@ -10,6 +10,7 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "mythread.h"
 #include "filter_encoder.h"
 #include "easy_preset.h"
 #include "block_encoder.h"


### PR DESCRIPTION
Hi! tukaani-project members!

In the process of my personal project, I made it possible to compile liblzma with WebAssembly as the target, so please use it if you like.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and without warnings or errors
- [x] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Build failed with rust+wasi-sdk.
```
"clang" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "--target=wasm32-wasi" "--sysroot" "/wasi-sdk-20.0/share/wasi-sysroot" "-D_WASI_EMULATED_SIGNAL" "-I" "xz-5.2/src/liblzma/api" "-I" "xz-5.2/src/liblzma/lzma" "-I" "xz-5.2/src/liblzma/lz" "-I" "xz-5.2/src/liblzma/check" "-I" "xz-5.2/src/liblzma/simple" "-I" "xz-5.2/src/liblzma/delta" "-I" "xz-5.2/src/liblzma/common" "-I" "xz-5.2/src/liblzma/rangecoder" "-I" "xz-5.2/src/common" "-I" "/xz2-rs/lzma-sys" "-std=c99" "-pthread" "-DHAVE_CONFIG_H=1" "-o" "/xz2-rs/target/wasm32-wasi/debug/build/lzma-sys-7bbeecf3b4119da3/out/xz-5.2/src/liblzma/check/check.o" "-c" "xz-5.2/src/liblzma/check/check.c"
  cargo:warning=In file included from xz-5.2/src/liblzma/check/check.c:13:
  cargo:warning=In file included from xz-5.2/src/liblzma/check/check.h:16:
  cargo:warning=In file included from xz-5.2/src/liblzma/common/common.h:17:
  cargo:warning=xz-5.2/src/common/mythread.h:146:12: warning: call to undeclared function 'pthread_sigmask'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  cargo:warning=        int ret = pthread_sigmask(how, set, oset);
  cargo:warning=                  ^
  cargo:warning=xz-5.2/src/common/mythread.h:160:2: warning: call to undeclared function 'sigfillset'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  cargo:warning=        sigfillset(&all);
  cargo:warning=        ^
  cargo:warning=xz-5.2/src/common/mythread.h:162:19: error: use of undeclared identifier 'SIG_SETMASK'
  cargo:warning=        mythread_sigmask(SIG_SETMASK, &all, &old);
  cargo:warning=                         ^
  cargo:warning=xz-5.2/src/common/mythread.h:164:19: error: use of undeclared identifier 'SIG_SETMASK'
  cargo:warning=        mythread_sigmask(SIG_SETMASK, &old, NULL);
  cargo:warning=                         ^
  cargo:warning=2 warnings and 2 errors generated.
  exit status: 1
```

<!-- Related issue this PR addresses, if applicable -->
<!-- Related Issue URL: -->

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->

- Optimize to include `mythread.h` only where necessary
- Build liblzma with `ENABLE_THREADS=OFF` now passes with the latest [wasi-sdk](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-20)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR. -->