### PR TITLE
Support build target `wasm32-unknown-unknown` in clang when `ENABLE_THREADS=OFF`

### DIFF
--- a/src/common/mythread.h
+++ b/src/common/mythread.h
@@ -79,7 +79,7 @@ do { \
 } while (0)
 
 
-#if !(defined(_WIN32) && !defined(__CYGWIN__))
+#if !((defined(_WIN32) && !defined(__CYGWIN__)) || defined(__wasm__))
 // Use sigprocmask() to set the signal mask in single-threaded programs.
 #include <signal.h>
 


### PR DESCRIPTION
Thanks for the review #56 yesterday!

I tried another approach, could you please review this one?

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and without warnings or errors
- [x] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
```
$ mkdir build && cd build
$ cmake .. -DENABLE_THREADS=OFF
$ make liblzma
[  0%] Building C object CMakeFiles/liblzma.dir/src/common/tuklib_physmem.c.obj                                       
[  1%] Building C object CMakeFiles/liblzma.dir/src/liblzma/check/check.c.obj                                         
In file included from /xz/src/liblzma/check/check.c:13:                                                               
In file included from /xz/src/liblzma/check/check.h:16:                                                               
In file included from /xz/src/liblzma/common/common.h:17:
In file included from /xz/src/common/mythread.h:84:
/wasi-sysroot/include/signal.h:2:2: error: "wasm lacks signal support; to enable minimal signal emulation, compile with -D_WASI_EMULATED_SIGNAL and link with -lwasi-emulated-signal"
#error "wasm lacks signal support; to enable minimal signal emulation, \
 ^
In file included from /xz/src/liblzma/check/check.c:13:
In file included from /xz/src/liblzma/check/check.h:16:
In file included from /xz/src/liblzma/common/common.h:17:
/xz/src/common/mythread.h:87:33: error: unknown type name 'sigset_t'
mythread_sigmask(int how, const sigset_t *restrict set,
                                ^
/xz/src/common/mythread.h:88:3: error: unknown type name 'sigset_t'
                sigset_t *restrict oset)
                ^
/xz/src/common/mythread.h:90:12: error: call to undeclared function 'sigprocmask'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        int ret = sigprocmask(how, set, oset);
                  ^
4 errors generated.
make[3]: *** [CMakeFiles/liblzma.dir/build.make:90: CMakeFiles/liblzma.dir/src/liblzma/check/check.c.obj] Error 1
make[2]: *** [CMakeFiles/Makefile2:139: CMakeFiles/liblzma.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:146: CMakeFiles/liblzma.dir/rule] Error 2
make: *** [Makefile:179: liblzma] Error 2
```

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: 
#56 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->

- Changed to exclude signal functions not supported by WebAssembly using the predefined `__wasm__` macro when the build target is set to wasm32 with clang.
This change allows `liblzma` to be built with the platform-independent `wasm32-uknown-unknown` target.
I believe this exclusion will work in the same way as the build when targeting Windows, so it will minimize unexpected changes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information

Build tested on docker

`Dockerfile`
```docker
FROM ghcr.io/webassembly/wasi-sdk:latest

RUN apt update && apt install -y git

RUN git clone https://github.com/ChanTsune/xz.git

RUN mkdir -p ./xz/build

RUN cd xz && git fetch && git switch feature/liblzma/wasm

WORKDIR /xz/build

RUN cmake .. -DENABLE_THREADS=OFF

RUN CFLAGS="-target wasm32-unknown-unknown" make liblzma
```

```sh
$ docker build -t xz .
```

If you need, you can see the predefined macros when targeting wasm32 in clang by following commands
```
$ clang -E -dM -target wasm32-unknown-unknown -x c /dev/null
```
or if you want to check with the latest wasi-sdk clang
```sh
$ docker image pull ghcr.io/webassembly/wasi-sdk
$ docker run --rm -i ghcr.io/webassembly/wasi-sdk clang-16 -E -dM -target wasm32-unknown-unknown -x c /dev/null
```
