### PR TITLE
Crc32 clmul

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ add_library(liblzma
     src/liblzma/api/lzma/vli.h
     src/liblzma/check/check.c
     src/liblzma/check/check.h
-    src/liblzma/check/crc_macros.h
+    src/liblzma/check/crc_common.h
     src/liblzma/common/block_util.c
     src/liblzma/common/common.c
     src/liblzma/common/common.h

--- a/src/liblzma/check/Makefile.inc
+++ b/src/liblzma/check/Makefile.inc
@@ -12,7 +12,7 @@ EXTRA_DIST += \
 liblzma_la_SOURCES += \
 	check/check.c \
 	check/check.h \
-	check/crc_macros.h
+	check/crc_common.h
 
 if COND_CHECK_CRC32
 if COND_SMALL

--- a/src/liblzma/check/crc32_fast.c
+++ b/src/liblzma/check/crc32_fast.c
@@ -3,13 +3,28 @@
 /// \file       crc32.c
 /// \brief      CRC32 calculation
 ///
-/// Calculate the CRC32 using the slice-by-eight algorithm.
+/// There are two methods in this file.
+/// crc32_generic uses the slice-by-eight algorithm.
 /// It is explained in this document:
 /// http://www.intel.com/technology/comms/perfnet/download/CRC_generators.pdf
 /// The code in this file is not the same as in Intel's paper, but
 /// the basic principle is identical.
+///
+/// crc32_clmul uses 32/64-bit x86 SSSE3, SSE4.1, and CLMUL instructions.
+/// It was derived from
+/// https://www.researchgate.net/publication/263424619_Fast_CRC_computation
+/// and the public domain code from https://github.com/rawrunprotected/crc
+/// (URLs were checked on 2023-09-29).
+///
+/// FIXME: Builds for 32-bit x86 use crc32_x86.S by default instead
+/// of this file and thus CLMUL version isn't available on 32-bit x86
+/// unless configured with --disable-assembler. Even then the lookup table
+/// isn't omitted in crc32_table.c since it doesn't know that assembly
+/// code has been disabled.
 //
-//  Author:     Lasse Collin
+//  Authors:    Lasse Collin
+//              Ilya Kurdyukov
+//              Hans Jansen
 //
 //  This file has been put into the public domain.
 //  You can do whatever you want with this file.
@@ -19,12 +34,14 @@
 #include "check.h"
 #include "crc_common.h"
 
+///////////////////
+// Generic CRC32 //
+///////////////////
+#ifdef CRC_GENERIC
 
-// If you make any changes, do some benchmarking! Seemingly unrelated
-// changes can very easily ruin the performance (and very probably is
-// very compiler dependent).
-extern LZMA_API(uint32_t)
-lzma_crc32(const uint8_t *buf, size_t size, uint32_t crc)
+
+static uint32_t
+crc32_generic(const uint8_t *buf, size_t size, uint32_t crc)
 {
 	crc = ~crc;
 
@@ -80,3 +97,219 @@ lzma_crc32(const uint8_t *buf, size_t size, uint32_t crc)
 
 	return ~crc;
 }
+#endif
+
+
+/////////////////////
+// x86 CLMUL CRC32 //
+/////////////////////
+
+#ifdef CRC_CLMUL
+
+#include <immintrin.h>
+
+
+/*
+// These functions were used to generate the constants
+// at the top of crc32_clmul().
+static uint64_t
+calc_lo(uint64_t p, uint64_t a, int n)
+{
+	uint64_t b = 0; int i;
+	for (i = 0; i < n; i++) {
+		b = b >> 1 | (a & 1) << (n - 1);
+		a = (a >> 1) ^ ((0 - (a & 1)) & p);
+	}
+	return b;
+}
+
+// same as ~crc(&a, sizeof(a), ~0)
+static uint64_t
+calc_hi(uint64_t p, uint64_t a, int n)
+{
+	int i;
+	for (i = 0; i < n; i++)
+		a = (a >> 1) ^ ((0 - (a & 1)) & p);
+	return a;
+}
+*/
+
+
+// MSVC (VS2015 - VS2022) produces bad 32-bit x86 code from the CLMUL CRC
+// code when optimizations are enabled (release build). According to the bug
+// report, the ebx register is corrupted and the calculated result is wrong.
+// Trying to workaround the problem with "__asm mov ebx, ebx" didn't help.
+// The following pragma works and performance is still good. x86-64 builds
+// aren't affected by this problem.
+//
+// NOTE: Another pragma after the function restores the optimizations.
+// If the #if condition here is updated, the other one must be updated too.
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__clang__) \
+		&& defined(_M_IX86)
+#	pragma optimize("g", off)
+#endif
+
+// EDG-based compilers (Intel's classic compiler and compiler for E2K) can
+// define __GNUC__ but the attribute must not be used with them.
+// The new Clang-based ICX needs the attribute.
+//
+// NOTE: Build systems check for this too, keep them in sync with this.
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__EDG__)
+__attribute__((__target__("ssse3,sse4.1,pclmul")))
+#endif
+static uint32_t
+crc32_clmul(const uint8_t *buf, size_t size, uint32_t crc)
+{
+	// The prototypes of the intrinsics use signed types while most of
+	// the values are treated as unsigned here. These warnings in this
+	// function have been checked and found to be harmless so silence them.
+#if TUKLIB_GNUC_REQ(4, 6) || defined(__clang__)
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wsign-conversion"
+#	pragma GCC diagnostic ignored "-Wconversion"
+#endif
+
+#ifndef CRC_USE_GENERIC_FOR_SMALL_INPUTS
+	// The code assumes that there is at least one byte of input.
+	if (size == 0)
+		return crc;
+#endif
+
+	// uint32_t poly = 0xedb88320;
+	uint64_t p = 0x1db710640; // p << 1
+	uint64_t mu = 0x1f7011641; // calc_lo(p, p, 32) << 1 | 1
+	uint64_t k5 = 0x163cd6124; // calc_hi(p, p, 32) << 1
+	uint64_t k4 = 0x0ccaa009e; // calc_hi(p, p, 64) << 1
+	uint64_t k3 = 0x1751997d0; // calc_hi(p, p, 128) << 1
+
+	__m128i vfold4 = _mm_set_epi64x(mu, p);
+	__m128i vfold8 = _mm_set_epi64x(0, k5);
+	__m128i vfold16 = _mm_set_epi64x(k4, k3);
+
+	__m128i v0, v1, v2;
+
+	crc_simd_body(buf,  size, &v0, &v1, vfold16, _mm_cvtsi32_si128(~crc));
+
+	v1 = _mm_xor_si128(
+			_mm_clmulepi64_si128(v0, vfold16, 0x10), v1); // xxx0
+	v2 = _mm_shuffle_epi32(v1, 0xe7); // 0xx0
+	v0 = _mm_slli_epi64(v1, 32);  // [0]
+	v0 = _mm_clmulepi64_si128(v0, vfold8, 0x00);
+	v0 = _mm_xor_si128(v0, v2);   // [1] [2]
+	v2 = _mm_clmulepi64_si128(v0, vfold4, 0x10);
+	v2 = _mm_clmulepi64_si128(v2, vfold4, 0x00);
+	v0 = _mm_xor_si128(v0, v2);   // [2]
+	return ~_mm_extract_epi32(v0, 2);
+
+#if TUKLIB_GNUC_REQ(4, 6) || defined(__clang__)
+#	pragma GCC diagnostic pop
+#endif
+}
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__clang__) \
+		&& defined(_M_IX86)
+#	pragma optimize("", on)
+#endif
+#endif
+
+#if defined(CRC_GENERIC) && defined(CRC_CLMUL)
+typedef uint32_t (*crc32_func_type)(
+		const uint8_t *buf, size_t size, uint32_t crc);
+
+// Clang 16.0.0 and older has a bug where it marks the ifunc resolver
+// function as unused since it is static and never used outside of
+// __attribute__((__ifunc__())).
+#if defined(HAVE_FUNC_ATTRIBUTE_IFUNC) && defined(__clang__)
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
+static crc32_func_type
+crc32_resolve(void)
+{
+	return is_clmul_supported() ? &crc32_clmul : &crc32_generic;
+}
+
+#if defined(HAVE_FUNC_ATTRIBUTE_IFUNC) && defined(__clang__)
+#	pragma GCC diagnostic pop
+#endif
+
+#ifndef HAVE_FUNC_ATTRIBUTE_IFUNC
+
+#ifdef HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR
+#	define CRC32_SET_FUNC_ATTR __attribute__((__constructor__))
+static crc32_func_type crc32_func;
+#else
+#	define CRC32_SET_FUNC_ATTR
+static uint32_t crc32_dispatch(const uint8_t *buf, size_t size, uint32_t crc);
+static crc32_func_type crc32_func = &crc32_dispatch;
+#endif
+
+CRC32_SET_FUNC_ATTR
+static void
+crc32_set_func(void)
+{
+	crc32_func = crc32_resolve();
+	return;
+}
+
+#ifndef HAVE_FUNC_ATTRIBUTE_CONSTRUCTOR
+static uint32_t
+crc32_dispatch(const uint8_t *buf, size_t size, uint32_t crc)
+{
+	// When __attribute__((__ifunc__(...))) and
+	// __attribute__((__constructor__)) isn't supported, set the
+	// function pointer without any locking. If multiple threads run
+	// the detection code in parallel, they will all end up setting
+	// the pointer to the same value. This avoids the use of
+	// mythread_once() on every call to lzma_crc32() but this likely
+	// isn't strictly standards compliant. Let's change it if it breaks.
+	crc32_set_func();
+	return crc32_func(buf, size, crc);
+}
+
+#endif
+#endif
+#endif
+
+
+#if defined(CRC_GENERIC) && defined(CRC_CLMUL) \
+		&& defined(HAVE_FUNC_ATTRIBUTE_IFUNC)
+extern LZMA_API(uint32_t)
+lzma_crc32(const uint8_t *buf, size_t size, uint32_t crc)
+		__attribute__((__ifunc__("crc32_resolve")));
+#else
+extern LZMA_API(uint32_t)
+lzma_crc32(const uint8_t *buf, size_t size, uint32_t crc)
+{
+#if defined(CRC_GENERIC) && defined(CRC_CLMUL)
+	// If CLMUL is available, it is the best for non-tiny inputs,
+	// being over twice as fast as the generic slice-by-four version.
+	// However, for size <= 16 it's different. In the extreme case
+	// of size == 1 the generic version can be five times faster.
+	// At size >= 8 the CLMUL starts to become reasonable. It
+	// varies depending on the alignment of buf too.
+	//
+	// The above doesn't include the overhead of mythread_once().
+	// At least on x86-64 GNU/Linux, pthread_once() is very fast but
+	// it still makes lzma_crc32(buf, 1, crc) 50-100 % slower. When
+	// size reaches 12-16 bytes the overhead becomes negligible.
+	//
+	// So using the generic version for size <= 16 may give better
+	// performance with tiny inputs but if such inputs happen rarely
+	// it's not so obvious because then the lookup table of the
+	// generic version may not be in the processor cache.
+#ifdef CRC_USE_GENERIC_FOR_SMALL_INPUTS
+	if (size <= 16)
+		return crc32_generic(buf, size, crc);
+#endif
+
+	return crc32_func(buf, size, crc);
+
+#elif defined(CRC_CLMUL)
+	return crc32_clmul(buf, size, crc);
+
+#else
+	return crc32_generic(buf, size, crc);
+#endif
+}
+#endif

--- a/src/liblzma/check/crc32_fast.c
+++ b/src/liblzma/check/crc32_fast.c
@@ -17,7 +17,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "check.h"
-#include "crc_macros.h"
+#include "crc_common.h"
 
 
 // If you make any changes, do some benchmarking! Seemingly unrelated

--- a/src/liblzma/check/crc32_table.c
+++ b/src/liblzma/check/crc32_table.c
@@ -12,11 +12,22 @@
 
 #include "common.h"
 
+
+// FIXME: Compared to crc32_fast.c this has to check for __x86_64__ too
+// so that in 32-bit builds crc32_x86.S won't break due to a missing table.
+#if !defined(HAVE_ENCODERS) && ((defined(__x86_64__) && defined(__SSSE3__) \
+			&& defined(__SSE4_1__) && defined(__PCLMUL__)) \
+			|| (defined(__e2k__) && __iset__ >= 6))
+// No table needed. Use a typedef to avoid an empty translation unit.
+typedef void lzma_crc32_dummy;
+
+#else
 // Having the declaration here silences clang -Wmissing-variable-declarations.
 extern const uint32_t lzma_crc32_table[8][256];
 
-#ifdef WORDS_BIGENDIAN
-#	include "crc32_table_be.h"
-#else
-#	include "crc32_table_le.h"
+#       ifdef WORDS_BIGENDIAN
+#       	include "crc32_table_be.h"
+#       else
+#       	include "crc32_table_le.h"
+#       endif
 #endif

--- a/src/liblzma/check/crc64_fast.c
+++ b/src/liblzma/check/crc64_fast.c
@@ -77,7 +77,7 @@
 
 #ifdef CRC_GENERIC
 
-#include "crc_macros.h"
+#include "crc_common.h"
 
 
 #ifdef WORDS_BIGENDIAN

--- a/src/liblzma/check/crc64_fast.c
+++ b/src/liblzma/check/crc64_fast.c
@@ -10,9 +10,9 @@
 ///
 /// crc64_clmul uses 32/64-bit x86 SSSE3, SSE4.1, and CLMUL instructions.
 /// It was derived from
-/// https://www.intel.com/content/dam/www/public/us/en/documents/white-papers/fast-crc-computation-generic-polynomials-pclmulqdq-paper.pdf
+/// https://www.researchgate.net/publication/263424619_Fast_CRC_computation
 /// and the public domain code from https://github.com/rawrunprotected/crc
-/// (URLs were checked on 2022-11-07).
+/// (URLs were checked on 2023-09-29).
 ///
 /// FIXME: Builds for 32-bit x86 use crc64_x86.S by default instead
 /// of this file and thus CLMUL version isn't available on 32-bit x86
@@ -29,55 +29,13 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "check.h"
-
-#undef CRC_GENERIC
-#undef CRC_CLMUL
-#undef CRC_USE_GENERIC_FOR_SMALL_INPUTS
-
-// If CLMUL cannot be used then only the generic slice-by-four is built.
-#if !defined(HAVE_USABLE_CLMUL)
-#	define CRC_GENERIC 1
-
-// If CLMUL is allowed unconditionally in the compiler options then the
-// generic version can be omitted. Note that this doesn't work with MSVC
-// as I don't know how to detect the features here.
-//
-// NOTE: Keep this this in sync with crc64_table.c.
-#elif (defined(__SSSE3__) && defined(__SSE4_1__) && defined(__PCLMUL__)) \
-		|| (defined(__e2k__) && __iset__ >= 6)
-#	define CRC_CLMUL 1
-
-// Otherwise build both and detect at runtime which version to use.
-#else
-#	define CRC_GENERIC 1
-#	define CRC_CLMUL 1
-
-/*
-	// The generic code is much faster with 1-8-byte inputs and has
-	// similar performance up to 16 bytes  at least in microbenchmarks
-	// (it depends on input buffer alignment too). If both versions are
-	// built, this #define will use the generic version for inputs up to
-	// 16 bytes and CLMUL for bigger inputs. It saves a little in code
-	// size since the special cases for 0-16-byte inputs will be omitted
-	// from the CLMUL code.
-#	define CRC_USE_GENERIC_FOR_SMALL_INPUTS 1
-*/
-
-#	if defined(_MSC_VER)
-#		include <intrin.h>
-#	elif defined(HAVE_CPUID_H)
-#		include <cpuid.h>
-#	endif
-#endif
-
+#include "crc_common.h"
 
 /////////////////////////////////
 // Generic slice-by-four CRC64 //
 /////////////////////////////////
 
 #ifdef CRC_GENERIC
-
-#include "crc_common.h"
 
 
 #ifdef WORDS_BIGENDIAN
@@ -173,17 +131,6 @@ calc_hi(uint64_t poly, uint64_t a)
 */
 
 
-#define MASK_L(in, mask, r) \
-	r = _mm_shuffle_epi8(in, mask)
-
-#define MASK_H(in, mask, r) \
-	r = _mm_shuffle_epi8(in, _mm_xor_si128(mask, vsign))
-
-#define MASK_LH(in, mask, low, high) \
-	MASK_L(in, mask, low); \
-	MASK_H(in, mask, high)
-
-
 // MSVC (VS2015 - VS2022) produces bad 32-bit x86 code from the CLMUL CRC
 // code when optimizations are enabled (release build). According to the bug
 // report, the ebx register is corrupted and the calculated result is wrong.
@@ -205,14 +152,6 @@ calc_hi(uint64_t poly, uint64_t a)
 // NOTE: Build systems check for this too, keep them in sync with this.
 #if (defined(__GNUC__) || defined(__clang__)) && !defined(__EDG__)
 __attribute__((__target__("ssse3,sse4.1,pclmul")))
-#endif
-// The intrinsics use 16-byte-aligned reads from buf, thus they may read
-// up to 15 bytes before or after the buffer (depending on the alignment
-// of the buf argument). The values of the extra bytes are ignored.
-// This unavoidably trips -fsanitize=address so address sanitizier has
-// to be disabled for this function.
-#if lzma_has_attribute(__no_sanitize_address__)
-__attribute__((__no_sanitize_address__))
 #endif
 static uint64_t
 crc64_clmul(const uint8_t *buf, size_t size, uint64_t crc)
@@ -237,150 +176,24 @@ crc64_clmul(const uint8_t *buf, size_t size, uint64_t crc)
 	const uint64_t mu = 0x9c3e466c172963d5; // (calc_lo(poly) << 1) | 1
 	const uint64_t k2 = 0xdabe95afc7875f40; // calc_hi(poly, 1)
 	const uint64_t k1 = 0xe05dd497ca393ae4; // calc_hi(poly, k2)
-	const __m128i vfold0 = _mm_set_epi64x(p, mu);
-	const __m128i vfold1 = _mm_set_epi64x(k2, k1);
 
-	// Create a vector with 8-bit values 0 to 15. This is used to
-	// construct control masks for _mm_blendv_epi8 and _mm_shuffle_epi8.
-	const __m128i vramp = _mm_setr_epi32(
-			0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c);
+	const __m128i vfold8 = _mm_set_epi64x(p, mu);
+	const __m128i vfold16 = _mm_set_epi64x(k2, k1);
 
-	// This is used to inverse the control mask of _mm_shuffle_epi8
-	// so that bytes that wouldn't be picked with the original mask
-	// will be picked and vice versa.
-	const __m128i vsign = _mm_set1_epi8(0x80);
-
-	// Memory addresses A to D and the distances between them:
-	//
-	//     A           B     C         D
-	//     [skip_start][size][skip_end]
-	//     [     size2      ]
-	//
-	// A and D are 16-byte aligned. B and C are 1-byte aligned.
-	// skip_start and skip_end are 0-15 bytes. size is at least 1 byte.
-	//
-	// A = aligned_buf will initially point to this address.
-	// B = The address pointed by the caller-supplied buf.
-	// C = buf + size == aligned_buf + size2
-	// D = buf + size + skip_end == aligned_buf + size2 + skip_end
-	const size_t skip_start = (size_t)((uintptr_t)buf & 15);
-	const size_t skip_end = (size_t)((0U - (uintptr_t)(buf + size)) & 15);
-	const __m128i *aligned_buf = (const __m128i *)(
-			(uintptr_t)buf & ~(uintptr_t)15);
-
-	// If size2 <= 16 then the whole input fits into a single 16-byte
-	// vector. If size2 > 16 then at least two 16-byte vectors must
-	// be processed. If size2 > 16 && size <= 16 then there is only
-	// one 16-byte vector's worth of input but it is unaligned in memory.
-	//
-	// NOTE: There is no integer overflow here if the arguments are valid.
-	// If this overflowed, buf + size would too.
-	size_t size2 = skip_start + size;
-
-	// Masks to be used with _mm_blendv_epi8 and _mm_shuffle_epi8:
-	// The first skip_start or skip_end bytes in the vectors will have
-	// the high bit (0x80) set. _mm_blendv_epi8 and _mm_shuffle_epi8
-	// will produce zeros for these positions. (Bitwise-xor of these
-	// masks with vsign will produce the opposite behavior.)
-	const __m128i mask_start
-			= _mm_sub_epi8(vramp, _mm_set1_epi8(skip_start));
-	const __m128i mask_end = _mm_sub_epi8(vramp, _mm_set1_epi8(skip_end));
-
-	// Get the first 1-16 bytes into data0. If loading less than 16 bytes,
-	// the bytes are loaded to the high bits of the vector and the least
-	// significant positions are filled with zeros.
-	const __m128i data0 = _mm_blendv_epi8(_mm_load_si128(aligned_buf),
-			_mm_setzero_si128(), mask_start);
-	++aligned_buf;
+	__m128i v0, v1, v2;
 
 #if defined(__i386__) || defined(_M_IX86)
-	const __m128i initial_crc = _mm_set_epi64x(0, ~crc);
+	crc_simd_body(buf,  size, &v0, &v1, vfold16, _mm_set_epi64x(0, ~crc));
 #else
 	// GCC and Clang would produce good code with _mm_set_epi64x
 	// but MSVC needs _mm_cvtsi64_si128 on x86-64.
-	const __m128i initial_crc = _mm_cvtsi64_si128(~crc);
+	crc_simd_body(buf,  size, &v0, &v1, vfold16, _mm_cvtsi64_si128(~crc));
 #endif
 
-	__m128i v0, v1, v2, v3;
-
-#ifndef CRC_USE_GENERIC_FOR_SMALL_INPUTS
-	if (size <= 16) {
-		// Right-shift initial_crc by 1-16 bytes based on "size"
-		// and store the result in v1 (high bytes) and v0 (low bytes).
-		//
-		// NOTE: The highest 8 bytes of initial_crc are zeros so
-		// v1 will be filled with zeros if size >= 8. The highest 8
-		// bytes of v1 will always become zeros.
-		//
-		// [      v1      ][      v0      ]
-		//  [ initial_crc  ]                  size == 1
-		//   [ initial_crc  ]                 size == 2
-		//                [ initial_crc  ]    size == 15
-		//                 [ initial_crc  ]   size == 16 (all in v0)
-		const __m128i mask_low = _mm_add_epi8(
-				vramp, _mm_set1_epi8(size - 16));
-		MASK_LH(initial_crc, mask_low, v0, v1);
-
-		if (size2 <= 16) {
-			// There are 1-16 bytes of input and it is all
-			// in data0. Copy the input bytes to v3. If there
-			// are fewer than 16 bytes, the low bytes in v3
-			// will be filled with zeros. That is, the input
-			// bytes are stored to the same position as
-			// (part of) initial_crc is in v0.
-			MASK_L(data0, mask_end, v3);
-		} else {
-			// There are 2-16 bytes of input but not all bytes
-			// are in data0.
-			const __m128i data1 = _mm_load_si128(aligned_buf);
-
-			// Collect the 2-16 input bytes from data0 and data1
-			// to v2 and v3, and bitwise-xor them with the
-			// low bits of initial_crc in v0. Note that the
-			// the second xor is below this else-block as it
-			// is shared with the other branch.
-			MASK_H(data0, mask_end, v2);
-			MASK_L(data1, mask_end, v3);
-			v0 = _mm_xor_si128(v0, v2);
-		}
-
-		v0 = _mm_xor_si128(v0, v3);
-		v1 = _mm_alignr_epi8(v1, v0, 8);
-	} else
-#endif
-	{
-		const __m128i data1 = _mm_load_si128(aligned_buf);
-		MASK_LH(initial_crc, mask_start, v0, v1);
-		v0 = _mm_xor_si128(v0, data0);
-		v1 = _mm_xor_si128(v1, data1);
-
-#define FOLD \
-	v1 = _mm_xor_si128(v1, _mm_clmulepi64_si128(v0, vfold1, 0x00)); \
-	v0 = _mm_xor_si128(v1, _mm_clmulepi64_si128(v0, vfold1, 0x11));
-
-		while (size2 > 32) {
-			++aligned_buf;
-			size2 -= 16;
-			FOLD
-			v1 = _mm_load_si128(aligned_buf);
-		}
-
-		if (size2 < 32) {
-			MASK_H(v0, mask_end, v2);
-			MASK_L(v0, mask_end, v0);
-			MASK_L(v1, mask_end, v3);
-			v1 = _mm_or_si128(v2, v3);
-		}
-
-		FOLD
-		v1 = _mm_srli_si128(v0, 8);
-#undef FOLD
-	}
-
-	v1 = _mm_xor_si128(_mm_clmulepi64_si128(v0, vfold1, 0x10), v1);
-	v0 = _mm_clmulepi64_si128(v1, vfold0, 0x00);
-	v2 = _mm_clmulepi64_si128(v0, vfold0, 0x10);
-	v0 = _mm_xor_si128(_mm_xor_si128(v2, _mm_slli_si128(v0, 8)), v1);
+	v1 = _mm_xor_si128(_mm_clmulepi64_si128(v0, vfold16, 0x10), v1);
+	v0 = _mm_clmulepi64_si128(v1, vfold8, 0x00);
+	v2 = _mm_clmulepi64_si128(v0, vfold8, 0x10);
+	v0 = _mm_xor_si128(_mm_xor_si128(v1, _mm_slli_si128(v0, 8)), v2);
 
 #if defined(__i386__) || defined(_M_IX86)
 	return ~(((uint64_t)(uint32_t)_mm_extract_epi32(v0, 3) << 32) |
@@ -399,53 +212,7 @@ crc64_clmul(const uint8_t *buf, size_t size, uint64_t crc)
 #endif
 #endif
 
-
-////////////////////////
-// Detect CPU support //
-////////////////////////
-
 #if defined(CRC_GENERIC) && defined(CRC_CLMUL)
-static inline bool
-is_clmul_supported(void)
-{
-	int success = 1;
-	uint32_t r[4]; // eax, ebx, ecx, edx
-
-#if defined(_MSC_VER)
-	// This needs <intrin.h> with MSVC. ICC has it as a built-in
-	// on all platforms.
-	__cpuid(r, 1);
-#elif defined(HAVE_CPUID_H)
-	// Compared to just using __asm__ to run CPUID, this also checks
-	// that CPUID is supported and saves and restores ebx as that is
-	// needed with GCC < 5 with position-independent code (PIC).
-	success = __get_cpuid(1, &r[0], &r[1], &r[2], &r[3]);
-#else
-	// Just a fallback that shouldn't be needed.
-	__asm__("cpuid\n\t"
-			: "=a"(r[0]), "=b"(r[1]), "=c"(r[2]), "=d"(r[3])
-			: "a"(1), "c"(0));
-#endif
-
-	// Returns true if these are supported:
-	// CLMUL (bit 1 in ecx)
-	// SSSE3 (bit 9 in ecx)
-	// SSE4.1 (bit 19 in ecx)
-	const uint32_t ecx_mask = (1 << 1) | (1 << 9) | (1 << 19);
-	return success && (r[2] & ecx_mask) == ecx_mask;
-
-	// Alternative methods that weren't used:
-	//   - ICC's _may_i_use_cpu_feature: the other methods should work too.
-	//   - GCC >= 6 / Clang / ICX __builtin_cpu_supports("pclmul")
-	//
-	// CPUID decding is needed with MSVC anyway and older GCC. This keeps
-	// the feature checks in the build system simpler too. The nice thing
-	// about __builtin_cpu_supports would be that it generates very short
-	// code as is it only reads a variable set at startup but a few bytes
-	// doesn't matter here.
-}
-
-
 typedef uint64_t (*crc64_func_type)(
 		const uint8_t *buf, size_t size, uint64_t crc);
 

--- a/src/liblzma/check/crc_common.h
+++ b/src/liblzma/check/crc_common.h
@@ -1,9 +1,11 @@
 ///////////////////////////////////////////////////////////////////////////////
 //
 /// \file       crc_common.h
-/// \brief      Some endian-dependent macros for CRC32 and CRC64
+/// \brief      Some functions and macros for CRC32 and CRC64
 //
-//  Author:     Lasse Collin
+//  Authors:    Lasse Collin
+//              Ilya Kurdyukov
+//              Hans Jansen
 //
 //  This file has been put into the public domain.
 //  You can do whatever you want with this file.
@@ -27,4 +29,228 @@
 
 #	define S8(x) ((x) >> 8)
 #	define S32(x) ((x) >> 32)
+#endif
+
+
+#undef CRC_GENERIC
+#undef CRC_CLMUL
+#undef CRC_USE_GENERIC_FOR_SMALL_INPUTS
+
+// If CLMUL cannot be used then only the generic slice-by-four is built.
+#if !defined(HAVE_USABLE_CLMUL)
+#	define CRC_GENERIC 1
+
+// If CLMUL is allowed unconditionally in the compiler options then the
+// generic version can be omitted. Note that this doesn't work with MSVC
+// as I don't know how to detect the features here.
+//
+// NOTE: Keep this this in sync with crc32_table.c.
+#elif (defined(__SSSE3__) && defined(__SSE4_1__) && defined(__PCLMUL__)) \
+		|| (defined(__e2k__) && __iset__ >= 6)
+#	define CRC_CLMUL 1
+
+// Otherwise build both and detect at runtime which version to use.
+#else
+#	define CRC_GENERIC 1
+#	define CRC_CLMUL 1
+
+/*
+	// The generic code is much faster with 1-8-byte inputs and has
+	// similar performance up to 16 bytes  at least in microbenchmarks
+	// (it depends on input buffer alignment too). If both versions are
+	// built, this #define will use the generic version for inputs up to
+	// 16 bytes and CLMUL for bigger inputs. It saves a little in code
+	// size since the special cases for 0-16-byte inputs will be omitted
+	// from the CLMUL code.
+#	define CRC_USE_GENERIC_FOR_SMALL_INPUTS 1
+*/
+
+#	if defined(_MSC_VER)
+#		include <intrin.h>
+#	elif defined(HAVE_CPUID_H)
+#		include <cpuid.h>
+#	endif
+#endif
+
+////////////////////////
+// Detect CPU support //
+////////////////////////
+
+#if defined(CRC_GENERIC) && defined(CRC_CLMUL)
+static inline bool
+is_clmul_supported(void)
+{
+	int success = 1;
+	uint32_t r[4]; // eax, ebx, ecx, edx
+
+#if defined(_MSC_VER)
+	// This needs <intrin.h> with MSVC. ICC has it as a built-in
+	// on all platforms.
+	__cpuid(r, 1);
+#elif defined(HAVE_CPUID_H)
+	// Compared to just using __asm__ to run CPUID, this also checks
+	// that CPUID is supported and saves and restores ebx as that is
+	// needed with GCC < 5 with position-independent code (PIC).
+	success = __get_cpuid(1, &r[0], &r[1], &r[2], &r[3]);
+#else
+	// Just a fallback that shouldn't be needed.
+	__asm__("cpuid\n\t"
+			: "=a"(r[0]), "=b"(r[1]), "=c"(r[2]), "=d"(r[3])
+			: "a"(1), "c"(0));
+#endif
+
+	// Returns true if these are supported:
+	// CLMUL (bit 1 in ecx)
+	// SSSE3 (bit 9 in ecx)
+	// SSE4.1 (bit 19 in ecx)
+	const uint32_t ecx_mask = (1 << 1) | (1 << 9) | (1 << 19);
+	return success && (r[2] & ecx_mask) == ecx_mask;
+
+	// Alternative methods that weren't used:
+	//   - ICC's _may_i_use_cpu_feature: the other methods should work too.
+	//   - GCC >= 6 / Clang / ICX __builtin_cpu_supports("pclmul")
+	//
+	// CPUID decding is needed with MSVC anyway and older GCC. This keeps
+	// the feature checks in the build system simpler too. The nice thing
+	// about __builtin_cpu_supports would be that it generates very short
+	// code as is it only reads a variable set at startup but a few bytes
+	// doesn't matter here.
+}
+#endif
+
+
+#define MASK_L(in, mask, r) r = _mm_shuffle_epi8(in, mask);
+#define MASK_H(in, mask, r) \
+	r = _mm_shuffle_epi8(in, _mm_xor_si128(mask, vsign));
+#define MASK_LH(in, mask, low, high) \
+	MASK_L(in, mask, low) MASK_H(in, mask, high)
+
+#ifdef CRC_CLMUL
+
+#include <immintrin.h>
+
+
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__EDG__)
+__attribute__((__target__("ssse3,sse4.1,pclmul")))
+#endif
+#if lzma_has_attribute(__no_sanitize_address__)
+__attribute__((__no_sanitize_address__))
+#endif
+static inline void
+crc_simd_body(const uint8_t *buf, size_t size, __m128i *v0, __m128i *v1,
+		__m128i vfold16, __m128i crc2vec)
+{
+#if TUKLIB_GNUC_REQ(4, 6) || defined(__clang__)
+#	pragma GCC diagnostic push
+#	pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+	// Memory addresses A to D and the distances between them:
+	//
+	//     A           B     C         D
+	//     [skip_start][size][skip_end]
+	//     [     size2      ]
+	//
+	// A and D are 16-byte aligned. B and C are 1-byte aligned.
+	// skip_start and skip_end are 0-15 bytes. size is at least 1 byte.
+	//
+	// A = aligned_buf will initially point to this address.
+	// B = The address pointed by the caller-supplied buf.
+	// C = buf + size == aligned_buf + size2
+	// D = buf + size + skip_end == aligned_buf + size2 + skip_end
+	uintptr_t skip_start = (uintptr_t)buf & 15;
+	uintptr_t skip_end = -(uintptr_t)(buf + size) & 15;
+
+	// Create a vector with 8-bit values 0 to 15.
+	// This is used to construct control masks
+	// for _mm_blendv_epi8 and _mm_shuffle_epi8.
+	__m128i vramp = _mm_setr_epi32(
+			0x03020100, 0x07060504, 0x0b0a0908, 0x0f0e0d0c);
+
+	// This is used to inverse the control mask of _mm_shuffle_epi8
+	// so that bytes that wouldn't be picked with the original mask
+	// will be picked and vice versa.
+	__m128i vsign = _mm_set1_epi8(-0x80);
+
+	// Masks to be used with _mm_blendv_epi8 and _mm_shuffle_epi8
+	// The first skip_start or skip_end bytes in the vectors will hav
+	// the high bit (0x80) set. _mm_blendv_epi8 and _mm_shuffle_epi
+	// will produce zeros for these positions. (Bitwise-xor of thes
+	// masks with vsign will produce the opposite behavior.)
+	__m128i mask_start = _mm_sub_epi8(vramp, _mm_set1_epi8(skip_start));
+	__m128i mask_end = _mm_sub_epi8(vramp, _mm_set1_epi8(skip_end));
+
+	// If size2 <= 16 then the whole input fits into a single 16-byte
+	// vector. If size2 > 16 then at least two 16-byte vectors must
+	// be processed. If size2 > 16 && size <= 16 then there is only
+	// one 16-byte vector's worth of input but it is unaligned in memory.
+	//
+	// NOTE: There is no integer overflow here if the arguments
+	// are valid. If this overflowed, buf + size would too.
+	uintptr_t size2 = skip_start + size;
+	const __m128i *aligned_buf = (const __m128i*)((uintptr_t)buf & -16);
+	__m128i v2, v3, vcrc, data0;
+
+	vcrc = crc2vec;
+
+	// Get the first 1-16 bytes into data0. If loading less than 16
+	// bytes, the bytes are loaded to the high bits of the vector and
+	// the least significant positions are filled with zeros.
+	data0 = _mm_load_si128(aligned_buf);
+	data0 = _mm_blendv_epi8(data0, _mm_setzero_si128(), mask_start);
+	aligned_buf++;
+	if (size2 <= 16) {
+		//  There are 1-16 bytes of input and it is all
+		//  in data0. Copy the input bytes to v3. If there
+		//  are fewer than 16 bytes, the low bytes in v3
+		//  will be filled with zeros. That is, the input
+		//  bytes are stored to the same position as
+		//  (part of) initial_crc is in v0.
+		__m128i mask_low = _mm_add_epi8(
+				vramp, _mm_set1_epi8(size - 16));
+		MASK_LH(vcrc, mask_low, *v0, *v1)
+		MASK_L(data0, mask_end, v3)
+		*v0 = _mm_xor_si128(*v0, v3);
+		*v1 = _mm_alignr_epi8(*v1, *v0, 8);
+	} else {
+		__m128i data1 = _mm_load_si128(aligned_buf);
+		if (size <= 16) {
+			//  Collect the 2-16 input bytes from data0 and data1
+			//  to v2 and v3, and bitwise-xor them with the
+			//  low bits of initial_crc in v0. Note that the
+			//  the second xor is below this else-block as it
+			//  is shared with the other branch.
+			__m128i mask_low = _mm_add_epi8(
+					vramp, _mm_set1_epi8(size - 16));
+			MASK_LH(vcrc, mask_low, *v0, *v1);
+			MASK_H(data0, mask_end, v2)
+			MASK_L(data1, mask_end, v3)
+			*v0 = _mm_xor_si128(*v0, v2);
+			*v0 = _mm_xor_si128(*v0, v3);
+
+			*v1 = _mm_alignr_epi8(*v1, *v0, 8);
+		} else {
+			const __m128i *end = (const __m128i*)(
+					(char*)aligned_buf++ - 16 + size2);
+			MASK_LH(vcrc, mask_start, *v0, *v1)
+			*v0 = _mm_xor_si128(*v0, data0);
+			*v1 = _mm_xor_si128(*v1, data1);
+			while (aligned_buf < end) {
+                                *v1 = _mm_xor_si128(*v1, _mm_clmulepi64_si128(*v0, vfold16, 0x00)); \
+	                        *v0 = _mm_xor_si128(*v1, _mm_clmulepi64_si128(*v0, vfold16, 0x11));
+                                *v1 = _mm_load_si128(aligned_buf++);
+                        }
+
+			if (aligned_buf != end) {
+				MASK_H(*v0, mask_end, v2)
+				MASK_L(*v0, mask_end, *v0)
+				MASK_L(*v1, mask_end, v3)
+				*v1 = _mm_or_si128(v2, v3);
+			}
+			*v1 = _mm_xor_si128(*v1, _mm_clmulepi64_si128(*v0, vfold16, 0x00));
+	                *v0 = _mm_xor_si128(*v1, _mm_clmulepi64_si128(*v0, vfold16, 0x11));
+
+			*v1 = _mm_srli_si128(*v0, 8);
+		}
+	}
+}
 #endif

--- a/src/liblzma/check/crc_common.h
+++ b/src/liblzma/check/crc_common.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 //
-/// \file       crc_macros.h
+/// \file       crc_common.h
 /// \brief      Some endian-dependent macros for CRC32 and CRC64
 //
 //  Author:     Lasse Collin


### PR DESCRIPTION
Added an implementation for crc32 that makes use of clmul.
Code for this implementation was written by Ilya Kurdyukov and can be found here.
https://github.com/ilyakurdyukov/crc-clmul-sim

Also refactored crc64_clmul to use the new macros created for crc32_clmul.
As well as moved similar functions to crc_clmul_common to eliminate duplicate code.

I tested this on files doubling in size starting from 1 byte up to 1 Gigabyte.
During testing I found that crc32_clmul can run up to 70% faster than crc32_generic,
and has an average speed increase of 58.4% for sizes greater than 16 bytes.

I also used this to test the reworked version of crc64_clmul.
This version of crc64_clmul is an average of 3.9% faster than the original implementation.
This speed increase is due to some inline assembly as well as changing around the order of some if statements. 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build was run locally and without warnings or errors
- [X] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
crc32\_fast currently only uses a generic implementation.


## What is the new behavior?
I added an implementation for crc32 that makes use of clmul in crc32_fast.c 
Also refactored crc64_clmul implementation to use the same macros as crc32_clmul


## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Other information

Here is the output from both tests that gave me the statistics above.

the number of unique files tested on and the number of times the crc is run
decrease as the bytes get larger so the benchmark does not take too long.

The 64 and 32 spd+ show the percentage speed increase over the generic.
The percentage on the graph show the combined average for all types.
For example (50% is twice as fast, 200% is twice as slow)
```
64 generic: #		64 clmul: +
32 generic: =		32 clmul: *

#bytes, #files,   #crc's,  64spd+,  32spd+: 0%          50%          100%        150%         200%
    16,  30000, 20648881,  39.96%,  24.24%: |           |      +*    | =    #    |            |
    32,  30000, 12782640,  55.79%,  36.26%: |           |   +*       |  =        #            |
    64,  30000,  7255012,  72.19%,  50.27%: |           +*           | =         |       #    |
   128,  30000,  3890368,  82.53%,  69.13%: |       +*  |            |    =      |            |#
   256,  30000,  2018311,  82.19%,  68.21%: |        +  |            |   =       |            |#
   512,  30000,  1028488,  79.37%,  63.75%: |         + |            |  =        |            #
    1K,  30000,   519217,  78.11%,  62.22%: |         + |            |   =       |           #|
    2K,  30000,   260870,  76.74%,  61.71%: |          +|            |  =        |          # |
    4K,  30000,   130752,  76.78%,  60.15%: |          +|            |  =        |          # |
    8K,  30000,    65456,  76.24%,  60.59%: |          +|            |  =        |          # |
   16K,  30000,    32748,  76.66%,  60.03%: |          +|            |  =        |          # |
   32K,  30000,    16379,  76.78%,  60.04%: |          +|            |  =        |          # |
   64K,  16384,     8190,  76.62%,  59.76%: |          +|            |  =        |          # |
  128K,   8192,     4095,  76.52%,  59.71%: |          +|            |  =        |          # |
  256K,   4096,     2047,  76.32%,  59.78%: |          +|            |  =        |          # |
  512K,   2048,     1023,  84.70%,  60.09%: |        +  |         =  |           |            |       #
    1M,   1024,      511,  76.71%,  60.29%: |          +|            |  =        |          # |
    2M,    512,      255,  76.47%,  59.96%: |          +|            |  =        |          # |
    4M,    256,      127,  76.42%,  60.03%: |          +|            |  =        |          # |
    8M,    128,       63,  76.33%,  60.22%: |          +|            |  =        |          # |
   16M,     64,       31,  76.55%,  60.23%: |          +|            |  =        |          # |
   32M,     32,       15,  76.14%,  60.66%: |          +|            |  =        |          # |
   64M,     16,       10,  76.53%,  59.99%: |          +|            |  =        |          # |
  128M,      8,       10,  76.27%,  60.28%: |          +|            |  =        |          # |
  256M,      4,       10,  76.42%,  59.96%: |          +|            |  =        |          # |
  512M,      2,       10,  76.45%,  60.23%: |          +|            |  =        |          # |
    1G,      1,       10,  76.64%,  60.19%: |          +|            |  =        |          # |
total average:             75.13%,  58.44%

```


The 64old and 64new spd+ show the percentage speed increase over the generic.
The percentage on the graph show the combined average for all types.
```
64 generic: #     64 clmul old: +     64 clmul new: *

#bytes, #files,   #crc's, old64spd+, new64spd+: 0%          50%          100%        150%         200%
     1,  30000, 48806446,  -97.328%,  -88.708%, |           | #          | * +       |            |
     2,  30000, 44739242,  -57.943%,  -48.621%, |           |     #      |* +        |            |
     4,  30000, 38347922,   -9.964%,   -4.811%, |           |          #*|+          |            |
     8,  30000, 29826161,   -0.558%,    3.477%, |           |           *+           |            |
    16,  30000, 20648881,   39.017%,   41.582%, |           |        +   |         # |            |
    32,  30000, 12782640,   54.057%,   54.848%, |           |      +     |           |    #       |
    64,  30000,  7255012,   69.551%,   70.777%, |           |  *+        |           |            | #
   128,  30000,  3890368,   81.047%,   81.603%, |          *+            |           |            |            #
   256,  30000,  2018311,   81.129%,   81.619%, |          +|            |           |            |           #
   512,  30000,  1028488,   77.798%,   79.257%, |           *+           |           |            |         #
    1K,  30000,   519217,   75.448%,   77.138%, |           |*+          |           |            |       #
    2K,  30000,   260870,   73.763%,   75.518%, |           |*+          |           |            |     #
    4K,  30000,   130752,   73.392%,   75.773%, |           |* +         |           |            |     #
    8K,  30000,    65456,   74.341%,   76.026%, |           |*+          |           |            |      #
   16K,  30000,    32748,   68.951%,   70.712%, |           |  *+        |           |            | #
   32K,  30000,    16379,   73.761%,   76.129%, |           |*+          |           |            |      #
   64K,  16384,     8190,   74.789%,   76.561%, |           |*+          |           |            |      #
  128K,   8192,     4095,   74.834%,   75.900%, |           |*+          |           |            |      #
  256K,   4096,     2047,   74.508%,   76.488%, |           |*+          |           |            |      #
  512K,   2048,     1023,   74.781%,   75.998%, |           |*+          |           |            |      #
    1M,   1024,      511,   74.523%,   76.610%, |           |*+          |           |            |      #
    2M,    512,      255,   74.871%,   76.690%, |           |*+          |           |            |      #
    4M,    256,      127,   74.656%,   76.658%, |           |*+          |           |            |      #
    8M,    128,       63,   74.151%,   76.085%, |           |*+          |           |            |      #
   16M,     64,       31,   74.802%,   76.263%, |           |*+          |           |            |      #
   32M,     32,       15,   74.671%,   76.244%, |           |*+          |           |            |      #
   64M,     16,       10,   74.626%,   76.459%, |           |*+          |           |            |      #
  128M,      8,       10,   74.738%,   76.497%, |           |*+          |           |            |      #
  256M,      4,       10,   74.395%,   76.110%, |           |*+          |           |            |      #
  512M,      2,       10,   74.904%,   76.549%, |           |*+          |           |            |      #
    1G,      1,       10,   74.709%,   76.477%, |           |*+          |           |            |      #
total average:              57.949%,   60.255%, 
speed increase new vs old:  3.979%
```
