### PR TITLE
Fix missing semicolon

### DIFF
--- a/src/liblzma/lzma/fastpos_tablegen.c
+++ b/src/liblzma/lzma/fastpos_tablegen.c
@@ -13,6 +13,7 @@
 
 #include <inttypes.h>
 #include <stdio.h>
+#include "common.h"
 #include "fastpos.h"
 
 


### PR DESCRIPTION
```
fastpos.h:94:28: error: expected ';' before 'extern'
   94 | lzma_attr_visibility_hidden
      |                            ^
      |                            ;
   95 | extern const uint8_t lzma_fastpos[1 << FASTPOS_BITS];
      | ~~~~~~
```

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and without warnings or errors
- [ ] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this
PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR. -->