### PR TITLE
Speed up CRC32 calculation on LoongArch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,7 @@ add_library(liblzma
     src/liblzma/check/crc_common.h
     src/liblzma/check/crc_x86_clmul.h
     src/liblzma/check/crc32_arm64.h
+    src/liblzma/check/crc32_loongarch.h
     src/liblzma/common/block_util.c
     src/liblzma/common/common.c
     src/liblzma/common/common.h
@@ -1153,6 +1154,33 @@ if(ALLOW_ARM64_CRC32)
         # sysctlbyname("hw.optional.armv8_crc32", ...).
         check_symbol_exists(sysctlbyname sys/sysctl.h HAVE_SYSCTLBYNAME)
         tuklib_add_definition_if(liblzma HAVE_SYSCTLBYNAME)
+    endif()
+endif()
+
+# LoongArch CRC32 Intrinsics are in larchintrin.h.
+# These are supported by at least GCC and Clang.
+option(ALLOW_LOONGARCH_CRC32 "Allow LoongArch CRC32 instruction if \
+supported by the system" ON)
+
+if(ALLOW_LOONGARCH_CRC32)
+    check_c_source_compiles("
+            // As at now only 64-bit LoongArch is supported.
+            #if !(defined(__loongarch__) && __loongarch_grlen >= 64)
+            #   error LoongArch CRC32 only supported on 64-bit LoongArch
+            #endif
+
+            #include <larchintrin.h>
+
+            int my_crc(int word, int crc)
+            {
+                return __crc_w_w_w(word, crc);
+            }
+            int main(void) { return 0; }
+        "
+        HAVE_LOONGARCH_CRC32)
+
+    if(HAVE_LOONGARCH_CRC32)
+        target_compile_definitions(liblzma PRIVATE HAVE_LOONGARCH_CRC32)
     endif()
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -394,6 +394,16 @@ AC_ARG_ENABLE([arm64-crc32], AS_HELP_STRING([--disable-arm64-crc32],
 	[], [enable_arm64_crc32=yes])
 
 
+################################
+# LoongArch CRC32 Instructions #
+################################
+
+AC_ARG_ENABLE([loongarch-crc32], AS_HELP_STRING([--disable-loongarch-crc32],
+		[Do not use LoongArch CRC32 instructions even if support for it
+		is detected.]),
+	[], [enable_loongarch_crc32=yes])
+
+
 #####################
 # Size optimization #
 #####################
@@ -1150,6 +1160,43 @@ uint32_t my_crc(uint32_t a, uint64_t b)
 # sysctlbyname("hw.optional.armv8_crc32", ...).
 AS_IF([test "x$enable_arm64_crc32" = xyes], [
 	AC_CHECK_FUNCS([getauxval elf_aux_info sysctlbyname])
+])
+
+# LoongArch Intrinsics define CRC32 functions in larchintrin.h.
+# These are supported by at least GCC and Clang.
+AC_MSG_CHECKING([if LoongArch CRC32 instruction is usable])
+AS_IF([test "x$enable_loongarch_crc32" = xno], [
+	AC_MSG_RESULT([no, --disable-loongarch-crc32 was used])
+], [
+	# Set -Werror here because -Wimplicit-function-declaration was
+	# only a warning in GCC <= 13. This does not need to be done
+	# with CMake because tests will attempt to link and the error
+	# will be reported then.
+	OLD_CFLAGS="$CFLAGS"
+	CFLAGS="$CFLAGS -Werror"
+
+	AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+// As at now only 64-bit LoongArch is supported.
+#if !(defined(__loongarch__) && __loongarch_grlen >= 64)
+#	error
+#endif
+
+#include <larchintrin.h>
+int my_crc(int word, int crc)
+{
+	return __crc_w_w_w(word, crc);
+}
+	]])], [
+		AC_DEFINE([HAVE_LOONGARCH_CRC32], [1],
+			[Define to 1 if LoongArch CRC32 instruction is supported.
+			See configure.ac for details.])
+		enable_loongarch_crc32=yes
+	], [
+		enable_loongarch_crc32=no
+	])
+	AC_MSG_RESULT([$enable_loongarch_crc32])
+
+	CFLAGS="$OLD_CFLAGS"
 ])
 
 

--- a/src/liblzma/check/Makefile.inc
+++ b/src/liblzma/check/Makefile.inc
@@ -13,7 +13,8 @@ liblzma_la_SOURCES += \
 	check/check.h \
 	check/crc_common.h \
 	check/crc_x86_clmul.h \
-	check/crc32_arm64.h
+	check/crc32_arm64.h \
+	check/crc32_loongarch.h
 
 if COND_SMALL
 liblzma_la_SOURCES += check/crc32_small.c

--- a/src/liblzma/check/crc32_fast.c
+++ b/src/liblzma/check/crc32_fast.c
@@ -19,6 +19,8 @@
 #	include "crc_x86_clmul.h"
 #elif defined(CRC32_ARM64)
 #	include "crc32_arm64.h"
+#elif defined(CRC32_LOONGARCH)
+#   include "crc32_loongarch.h"
 #endif
 
 

--- a/src/liblzma/check/crc32_loongarch.h
+++ b/src/liblzma/check/crc32_loongarch.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: 0BSD
+
+///////////////////////////////////////////////////////////////////////////////
+//
+/// \file       crc32_loongarch.h
+/// \brief      CRC32 calculation with LoongArch optimization
+//
+//  Authors:    Xi Ruoyao
+//
+///////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef LZMA_CRC32_LOONGARCH_H
+#define LZMA_CRC32_LOONGARCH_H
+
+#include <larchintrin.h>
+
+static uint32_t
+crc32_arch_optimized(const uint8_t *buf, size_t size, uint32_t crc_unsigned)
+{
+	int32_t crc = (int32_t)~crc_unsigned;
+
+	// Align the input buffer because this was shown to be
+	// significantly faster than unaligned accesses.
+	const size_t align_amount = my_min(size,
+			(8 - (uintptr_t)buf) & (8 - 1));
+
+	if (align_amount & 1)
+		crc = __crc_w_b_w((int8_t)*buf++, crc);
+
+	if (align_amount & 2) {
+		crc = __crc_w_h_w((int16_t)aligned_read16le(buf), crc);
+		buf += 2;
+	}
+
+	if (align_amount & 4) {
+		crc = __crc_w_w_w((int32_t)aligned_read32le(buf), crc);
+		buf += 4;
+	}
+
+	size -= align_amount;
+
+	// Process 8 bytes at a time. The end point is determined by
+	// ignoring the least significant 3 bits of size to ensure
+	// we do not process past the bounds of the buffer. This guarantees
+	// that limit is a multiple of 8 and is strictly less than size.
+	for (const uint8_t *limit = buf + (size & ~(size_t)7);
+			buf < limit; buf += 8)
+		crc = __crc_w_d_w((int64_t)aligned_read64le(buf), crc);
+
+	// Process the remaining bytes that are not 8 byte aligned.
+	const size_t remaining_amount = size & 7;
+
+	if (remaining_amount & 4) {
+		crc = __crc_w_w_w((int32_t)aligned_read32le(buf), crc);
+		buf += 4;
+	}
+
+	if (remaining_amount & 2) {
+		crc = __crc_w_h_w((int16_t)aligned_read16le(buf), crc);
+		buf += 2;
+	}
+
+	if (remaining_amount & 1)
+		crc = __crc_w_b_w((int8_t)*buf, crc);
+
+	return (uint32_t)~crc;
+}
+
+
+#endif // LZMA_CRC32_LOONGARCH_H

--- a/src/liblzma/check/crc32_table.c
+++ b/src/liblzma/check/crc32_table.c
@@ -26,9 +26,14 @@
 #	define ARM64_CRC32_NO_TABLE 1
 #endif
 
+#if defined(HAVE_LOONGARCH_CRC32)
+#	define LOONGARCH_CRC32_NO_TABLE 1
+#endif
+
 
 #if !defined(HAVE_ENCODERS) && (defined(X86_CLMUL_NO_TABLE) \
-		|| defined(ARM64_CRC32_NO_TABLE_))
+		|| defined(ARM64_CRC32_NO_TABLE_) \
+		|| defined(LOONGARCH_CRC32_NO_TABLE))
 // No table needed. Use a typedef to avoid an empty translation unit.
 typedef void lzma_crc32_dummy;
 

--- a/src/liblzma/check/crc_common.h
+++ b/src/liblzma/check/crc_common.h
@@ -67,6 +67,8 @@
 #undef CRC32_ARM64
 #undef CRC64_ARM64_CLMUL
 
+#undef CRC32_LOONGARCH
+
 #undef CRC_USE_IFUNC
 
 #undef CRC_USE_GENERIC_FOR_SMALL_INPUTS
@@ -126,6 +128,15 @@
 #		endif
 */
 #	endif
+#endif
+
+// Only 64-bit LoongArch is supported now, thus no runtime detection is
+// needed because the LoongArch specification says CRC32 instructions are
+// a part of the Basic Integer Instructions and they shall be implemented
+// by 64-bit LoongArch implementations.
+#if defined(HAVE_LOONGARCH_CRC32)
+#	define CRC32_ARCH_OPTIMIZED 1
+#	define CRC32_LOONGARCH 1
 #endif
 
 // For CRC32 use the generic slice-by-eight implementation if no optimized


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and without warnings or errors
- [x] All previous and new tests pass


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple
pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

On LoongArch the generic table-based CRC32 implementation is used.

<!-- Related issue this PR addresses, if applicable -->
Related Issue URL: None


## What is the new behavior?

The crc.w.{b/h/w/d}.w instructions in LoongArch can calculate the CRC32 result for 1/2/4/8 bytes in a single operation, making the use of LoongArch CRC32 instructions much faster compared to the general CRC32 algorithm.

Optimized CRC32 will be enabled if the kernel declares the LoongArch CRC32 instructions supported via AT_HWCAP.

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and
migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR. -->