### PR TITLE
xz: Add missing RISC-V on the filter list in the man page

### DIFF
--- a/src/xz/xz.1
+++ b/src/xz/xz.1
@@ -4,7 +4,7 @@
 .\" Authors: Lasse Collin
 .\"          Jia Tan
 .\"
-.TH XZ 1 "2024-02-13" "Tukaani" "XZ Utils"
+.TH XZ 1 "2024-02-25" "Tukaani" "XZ Utils"
 .
 .SH NAME
 xz, unxz, xzcat, lzma, unlzma, lzcat \- Compress or decompress .xz and .lzma files
@@ -1812,6 +1812,8 @@ and
 \fB\-\-ia64\fR[\fB=\fIoptions\fR]
 .TP
 \fB\-\-sparc\fR[\fB=\fIoptions\fR]
+.TP
+\fB\-\-riscv\fR[\fB=\fIoptions\fR]
 .PD
 Add a branch/call/jump (BCJ) filter to the filter chain.
 These filters can be used only as a non-last filter


### PR DESCRIPTION
## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and without warnings or errors
- [ ] All previous and new tests pass


## Pull request type 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The RISC-V filter option should be listed in the man page but not.


## What is the new behavior?
List the RISC-V filter.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

The translation is not handled yet.
Currently running po4a/update-po upon commit 5d8d915ebe2e345820a0f54d1baf8d7d4824c0c7 generates changes of over 455 lines and I'm sure sure if they are really needed. Plus, I'm not familiar with the po4a tools so help is needed. 