### PR TITLE
Build: Let the users override the symbol versioning variant.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -716,52 +716,61 @@ elif test "x$enable_shared" = xno ; then
 	enable_symbol_versions=no
 	AC_MSG_RESULT([no (not building a shared library)])
 else
-	case "$host_cpu-$host_os" in
-		microblaze*)
-			# GCC 12 on MicroBlaze doesn't support __symver__
-			# attribute. It's simplest and safest to use the
-			# generic version on that platform since then only
-			# the linker script is needed. The RHEL/CentOS 7
-			# compatibility symbols don't matter on MicroBlaze.
-			enable_symbol_versions=generic
-			;;
-		*-linux*)
-			case "$pic_mode-$enable_static" in
-				default-*)
-					# Use symvers if PIC is defined.
-					have_symbol_versions_linux=2
-					;;
-				*-no)
-					# Not building static library.
-					# Use symvers unconditionally.
-					have_symbol_versions_linux=1
-					;;
-				*)
-					AC_MSG_RESULT([])
-					AC_MSG_ERROR([
+	if test "x$enable_symbol_versions" = xyes ; then
+		case "$host_cpu-$host_os" in
+			microblaze*)
+				# GCC 12 on MicroBlaze doesn't support __symver__
+				# attribute. It's simplest and safest to use the
+				# generic version on that platform since then only
+				# the linker script is needed. The RHEL/CentOS 7
+				# compatibility symbols don't matter on MicroBlaze.
+				enable_symbol_versions=generic
+				;;
+			*-linux*)
+				enable_symbol_versions=linux
+				;;
+			*)
+				enable_symbol_versions=generic
+				;;
+		esac
+	fi
+
+	if test "x$enable_symbol_versions" = xlinux ; then
+		case "$pic_mode-$enable_static" in
+			default-*)
+				# Use symvers if PIC is defined.
+				have_symbol_versions_linux=2
+				;;
+			*-no)
+				# Not building static library.
+				# Use symvers unconditionally.
+				have_symbol_versions_linux=1
+				;;
+			*)
+				AC_MSG_RESULT([])
+				AC_MSG_ERROR([
     On GNU/Linux, building both shared and static library at the same time
     is not supported if --with-pic or --without-pic is used.
     Use either --disable-shared or --disable-static to build one type
     of library at a time. If both types are needed, build one at a time,
     possibly picking only src/liblzma/.libs/liblzma.a from the static build.])
-					;;
-			esac
-			enable_symbol_versions=linux
-			AC_DEFINE_UNQUOTED([HAVE_SYMBOL_VERSIONS_LINUX],
-				[$have_symbol_versions_linux],
-				[Define to 1 to if GNU/Linux-specific details
-				are unconditionally wanted for symbol
-				versioning. Define to 2 to if these are wanted
-				only if also PIC is defined (allows building
-				both shared and static liblzma at the same
-				time with Libtool if neither --with-pic nor
-				--without-pic is used). This define must be
-				used together with liblzma_linux.map.])
-			;;
-		*)
-			enable_symbol_versions=generic
-			;;
-	esac
+				;;
+		esac
+		AC_DEFINE_UNQUOTED([HAVE_SYMBOL_VERSIONS_LINUX],
+			[$have_symbol_versions_linux],
+			[Define to 1 to if GNU/Linux-specific details
+			are unconditionally wanted for symbol
+			versioning. Define to 2 to if these are wanted
+			only if also PIC is defined (allows building
+			both shared and static liblzma at the same
+			time with Libtool if neither --with-pic nor
+			--without-pic is used). This define must be
+			used together with liblzma_linux.map.])
+	elif test "x$enable_symbol_versions" != xgeneric ; then
+		AC_MSG_RESULT([])
+		AC_MSG_ERROR(
+			[unknown symbol versioning variant '$enable_symbol_versions'])
+	fi
 	AC_MSG_RESULT([yes ($enable_symbol_versions)])
 fi
 


### PR DESCRIPTION
There are cases when the users want to decide themselves whether they want to have the generic (even on GNU/Linux) or the linux (even if we do not recommend that) symbol versioning variant. The former might be needed to circumvent compiler issues (i.e. the compiler does not support all features that are required for the linux versioning), the latter might help in overriding the assumptions made in the configure script.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and without warnings or errors
- [x] All previous and new tests pass


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
It's not possible to override the symbol versioning variant on GNU/Linux:
```console
$ ./configure --enable-symbol-versions=auto | grep 'library symbol versioning'
checking if library symbol versioning should be used... yes (linux)
$ ./configure --enable-symbol-versions=yes | grep 'library symbol versioning'
checking if library symbol versioning should be used... yes (linux)
$ ./configure --enable-symbol-versions=no | grep 'library symbol versioning'
checking if library symbol versioning should be used... no
$ ./configure --enable-symbol-versions=linux | grep 'library symbol versioning'
checking if library symbol versioning should be used... yes (linux)
$ ./configure --enable-symbol-versions=generic | grep 'library symbol versioning'
checking if library symbol versioning should be used... yes (linux)
$ ./configure --enable-symbol-versions=something-else | grep 'library symbol versioning'
checking if library symbol versioning should be used... yes (linux)
$ ./configure --enable-symbol-versions --disable-shared | grep 'library symbol versioning'
checking if library symbol versioning should be used... no (not building a shared library)
$ ./configure --with-pic | grep 'library symbol versioning'
checking if library symbol versioning should be used... 
configure: error: 
    On GNU/Linux, building both shared and static library at the same time
    is not supported if --with-pic or --without-pic is used.
    Use either --disable-shared or --disable-static to build one type
    of library at a time. If both types are needed, build one at a time,
    possibly picking only src/liblzma/.libs/liblzma.a from the static build.
```

## What is the new behavior?
It is possible to override the symbol versioning variant:
```console
$ ./configure --enable-symbol-versions=auto | grep 'library symbol versioning'
checking if library symbol versioning should be used... yes (linux)
$ ./configure --enable-symbol-versions=yes | grep 'library symbol versioning'
checking if library symbol versioning should be used... yes (linux)
$ ./configure --enable-symbol-versions=no | grep 'library symbol versioning'
checking if library symbol versioning should be used... no
$ ./configure --enable-symbol-versions=linux | grep 'library symbol versioning'
checking if library symbol versioning should be used... yes (linux)
$ ./configure --enable-symbol-versions=generic | grep 'library symbol versioning'
checking if library symbol versioning should be used... yes (generic)
$ ./configure --enable-symbol-versions=something-else | grep 'library symbol versioning'
checking if library symbol versioning should be used... 
configure: error: unknown symbol versioning variant 'something-else'
$ ./configure --enable-symbol-versions --disable-shared | grep 'library symbol versioning'
checking if library symbol versioning should be used... no (not building a shared library)
$ ./configure --with-pic | grep 'library symbol versioning'
checking if library symbol versioning should be used... 
configure: error: 
    On GNU/Linux, building both shared and static library at the same time
    is not supported if --with-pic or --without-pic is used.
    Use either --disable-shared or --disable-static to build one type
    of library at a time. If both types are needed, build one at a time,
    possibly picking only src/liblzma/.libs/liblzma.a from the static build.
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

It looks like `--enable-symbol-versions=generic` was an unintended feature that existed before 0682439.