### PR TITLE
liblzma: Fix building with NVHPC (NVIDIA HPC SDK).

### DIFF
--- a/src/liblzma/common/string_conversion.c
+++ b/src/liblzma/common/string_conversion.c
@@ -217,12 +217,14 @@ typedef struct {
 	uint16_t offset;
 
 	union {
+// NVHPC has problems with unions that contain pointers that are not the first
+// members
+		const name_value_map *map;
+
 		struct {
 			uint32_t min;
 			uint32_t max;
 		} range;
-
-		const name_value_map *map;
 	} u;
 } option_map;
 

--- a/src/liblzma/delta/delta_decoder.c
+++ b/src/liblzma/delta/delta_decoder.c
@@ -25,6 +25,9 @@ decode_buffer(lzma_delta_coder *coder, uint8_t *buffer, size_t size)
 }
 
 
+#ifdef __NVCOMPILER
+#	pragma routine novector
+#endif
 static lzma_ret
 delta_decode(void *coder_ptr, const lzma_allocator *allocator,
 		const uint8_t *restrict in, size_t *restrict in_pos,

--- a/src/liblzma/rangecoder/range_decoder.h
+++ b/src/liblzma/rangecoder/range_decoder.h
@@ -45,6 +45,7 @@
 //     and different processors. Overall 0x1F0 seems to be the best choice.
 #ifndef LZMA_RANGE_DECODER_CONFIG
 #	if defined(__x86_64__) && !defined(__ILP32__) \
+			&& !defined(__NVCOMPILER) \
 			&& (defined(__GNUC__) || defined(__clang__))
 #		define LZMA_RANGE_DECODER_CONFIG 0x1F0
 #	else


### PR DESCRIPTION
NVHPC compiler has several issues that make it impossible to build liblzma:
  - the compiler cannot handle unions that contain pointers that are not the first members (in some cases);
  - the compiler cannot handle the assembler code in range_decoder.h (LZMA_RANGE_DECODER_CONFIG has to be set to zero);
  - the compiler fails to produce valid code for delta_decode if the vectorization is enabled, which results in failed tests.

This introduces NVHPC-specific workarounds that address the issues.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build was run locally and without warnings or errors
- [x] All previous and new tests pass


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming, typo fix)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): workarounds for the compiler


## What is the current behavior?
It's not possible to build and get the tests pass with any existing release of the NVHPC compiler even when configuring as follows:
```console
$ ./configure --disable-symbol-versions CPPFLAGS='-DLZMA_RANGE_DECODER_CONFIG=0' CFLAGS='-O'
```
(`-O` is the same as the default `-O2` but without SIMD)


## What is the new behavior?
It is possible to build and get the tests pass with any existing release of the NVHPC compiler when configuring as follows:
```console
$ ./configure --disable-symbol-versions
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

I don't know if there is any interest in supporting NVHPC and I'd understand if there's none.