### PR TITLE
cmake: overwrite user given NLS decision in case legacy cmake is detected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,9 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
         # The *installed* name of the translation files is "xz.mo".
         set(TRANSLATION_DOMAIN "xz")
     endif()
+else()
+    # This only sets the variable, not the cache variable!
+    set(XZ_NLS OFF)
 endif()
 
 # Add warning options for GCC or Clang. Keep this in sync with configure.ac.


### PR DESCRIPTION
Overwriteuser given NLS decision in case legacy cmake (e.g. 3.18.4) is detected.

Fixes:

  CMake Error at CMakeLists.txt:1675 (add_executable):
    Target "xz" links to target "Intl::Intl" but the target was not found.
    Perhaps a find_package() call is missing for an IMPORTED target, or an
    ALIAS target is missing?

  CMake Error at CMakeLists.txt:1619 (add_executable):
    Target "lzmainfo" links to target "Intl::Intl" but the target was not
    found.  Perhaps a find_package() call is missing for an IMPORTED target, or
    an ALIAS target is missing?


Closes: https://github.com/tukaani-project/xz/issues/129