### PR TITLE
liblzma: Fix incorrect macro name in a comment

### DIFF
--- a/src/liblzma/api/lzma/lzma12.h
+++ b/src/liblzma/api/lzma/lzma12.h
@@ -461,7 +461,7 @@ typedef struct {
 	 *
 	 * ext_size_low holds the least significant 32 bits of the
 	 * uncompressed size. The most significant 32 bits must be set
-	 * in ext_size_high. The macro lzma_ext_size_set(opt_lzma, u64size)
+	 * in ext_size_high. The macro lzma_set_ext_size(opt_lzma, u64size)
 	 * can be used to set these members.
 	 *
 	 * The 64-bit uncompressed size is split into two uint32_t variables


### PR DESCRIPTION
Very minor thing but this tripped me up. The comment references `lzma_ext_size_set` but this doesn't exist. It's supposed to say `lzma_set_ext_size`, with set at the start not the end.