### PR TITLE
CMake: Disable unity builds project-wide

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,12 @@ set(CMAKE_C_STANDARD 11)
 # On Apple OSes, don't build executables as bundles:
 set(CMAKE_MACOSX_BUNDLE OFF)
 
+# The targets defined here don't support compiling as a unity build. Encoder
+# and decoder source files define different types with the same name, and some
+# internal header files don't have header guards leading to redeclaration
+# errors.
+set(CMAKE_UNITY_BUILD OFF)
+
 # Set CMAKE_INSTALL_LIBDIR and friends. This needs to be done before
 # the LOCALEDIR_DEFINITION workaround below.
 include(GNUInstallDirs)


### PR DESCRIPTION
I have a project that uses xz via CMake's `FetchContent` module. This basically downloads xz and makes it part of the parent project using `add_subdirectory`.

After adding xz like this, I could no longer compile my project as a unity build because xz doesn't appear to support this. xz could certainly be modified to support this type of build, but that's not simply a one-time fix but a long term commitment.

<details>
<summary>These are the types of errors it generates:</summary>

```
In file included from /home/dexter/src/xz/src/liblzma/common/alone_decoder.c:14,
                 from /tmp/xz/CMakeFiles/liblzma.dir/Unity/unity_0_c.c:133:
/home/dexter/src/xz/src/liblzma/lz/lz_decoder.h:75:3: error: conflicting types for ‘lzma_lz_options’; have ‘struct <anonymous>’
   75 | } lzma_lz_options;
      |   ^~~~~~~~~~~~~~~
In file included from /home/dexter/src/xz/src/liblzma/lzma/lzma_encoder_private.h:16,
                 from /home/dexter/src/xz/src/liblzma/lzma/lzma_encoder.c:14:
/home/dexter/src/xz/src/liblzma/lz/lz_encoder.h:172:3: note: previous declaration of ‘lzma_lz_options’ with type ‘lzma_lz_options’
  172 | } lzma_lz_options;
      |   ^~~~~~~~~~~~~~~
```
```
/home/dexter/src/xz/src/xz/file_io.h:40:3: error: conflicting types for ‘io_buf’; have ‘union <anonymous>’
   40 | } io_buf;
      |   ^~~~~~
/home/dexter/src/xz/src/xz/file_io.h:40:3: note: previous declaration of ‘io_buf’ with type ‘io_buf’
   40 | } io_buf;
      |   ^~~~~~
```
</details>

This PR disables unity builds for the entire xz project directory. Because of how variable scoping works, if someone includes xz in their project and enables unity builds then it's still applied to any other part of the build that doesn't explicitly disable it for themselves.

Disabling unity builds when it doesn't work is recommended as per the `UNITY_BUILD` target property documentation:

>Projects should not directly set the `UNITY_BUILD` property or its associated `CMAKE_UNITY_BUILD` variable to true. [...] However, __it IS recommended to set the `UNITY_BUILD` property to false__ if it is known that enabling unity builds for target can lead to problems.

<hr>

Unity builds can sometimes reveal UB as compilation errors because the compiler can suddenly analyse across what would normally be separate compilation units. I just want to make it abundantly clear that I **DON'T** think that's what is going on here.

xz just employs some code patterns that happen to be incompatible with unity builds.