### PR TITLE
xz: Add --synchronous

### DIFF
--- a/src/xz/args.c
+++ b/src/xz/args.c
@@ -21,6 +21,7 @@
 bool opt_stdout = false;
 bool opt_force = false;
 bool opt_keep_original = false;
+bool opt_synchronous = false;
 bool opt_robot = false;
 bool opt_ignore_check = false;
 
@@ -217,6 +218,7 @@ parse_real(args_info *args, int argc, char **argv)
 		OPT_LZMA1,
 		OPT_LZMA2,
 
+		OPT_SYNCHRONOUS,
 		OPT_SINGLE_STREAM,
 		OPT_NO_SPARSE,
 		OPT_FILES,
@@ -249,6 +251,7 @@ parse_real(args_info *args, int argc, char **argv)
 		{ "force",        no_argument,       NULL,  'f' },
 		{ "stdout",       no_argument,       NULL,  'c' },
 		{ "to-stdout",    no_argument,       NULL,  'c' },
+		{ "synchronous",  no_argument,       NULL,  OPT_SYNCHRONOUS },
 		{ "single-stream", no_argument,      NULL,  OPT_SINGLE_STREAM },
 		{ "no-sparse",    no_argument,       NULL,  OPT_NO_SPARSE },
 		{ "suffix",       required_argument, NULL,  'S' },
@@ -653,6 +656,10 @@ parse_real(args_info *args, int argc, char **argv)
 		case OPT_FLUSH_TIMEOUT:
 			opt_flush_timeout = str_to_uint64("flush-timeout",
 					optarg, 0, UINT64_MAX);
+			break;
+
+		case OPT_SYNCHRONOUS:
+			opt_synchronous = true;
 			break;
 
 		default:

--- a/src/xz/args.h
+++ b/src/xz/args.h
@@ -34,7 +34,7 @@ typedef struct {
 extern bool opt_stdout;
 extern bool opt_force;
 extern bool opt_keep_original;
-// extern bool opt_recursive;
+extern bool opt_synchronous;
 extern bool opt_robot;
 extern bool opt_ignore_check;
 

--- a/src/xz/coder.c
+++ b/src/xz/coder.c
@@ -1244,6 +1244,12 @@ coder_normal(file_pair *pair)
 				if (coder_write_output(pair))
 					break;
 
+				// If --flush-timeout is combined with
+				// --synchronous, each flush is also
+				// synced to permanent storage.
+				if (opt_synchronous && io_sync_dest(pair))
+					break;
+
 				// Mark that we haven't seen any new input
 				// since the previous flush.
 				pair->src_has_seen_input = false;

--- a/src/xz/file_io.c
+++ b/src/xz/file_io.c
@@ -828,8 +828,7 @@ io_open_dest_real(file_pair *pair)
 						"a DOS special file",
 						tuklib_mask_nonprint(
 							pair->dest_name));
-				free(pair->dest_name);
-				return true;
+				goto error;
 			}
 
 			// Check that we aren't overwriting the source file.
@@ -839,8 +838,7 @@ io_open_dest_real(file_pair *pair)
 						"as the input file",
 						tuklib_mask_nonprint(
 							pair->dest_name));
-				free(pair->dest_name);
-				return true;
+				goto error;
 			}
 		}
 #endif
@@ -850,8 +848,7 @@ io_open_dest_real(file_pair *pair)
 			message_error(_("%s: Cannot remove: %s"),
 					tuklib_mask_nonprint(pair->dest_name),
 					strerror(errno));
-			free(pair->dest_name);
-			return true;
+			goto error;
 		}
 
 		// Open the file.
@@ -867,8 +864,7 @@ io_open_dest_real(file_pair *pair)
 			message_error(_("%s: %s"),
 					tuklib_mask_nonprint(pair->dest_name),
 					strerror(errno));
-			free(pair->dest_name);
-			return true;
+			goto error;
 		}
 	}
 
@@ -901,9 +897,7 @@ io_open_dest_real(file_pair *pair)
 		// dest_fd needs to be reset to -1 to keep io_close() working.
 		(void)close(pair->dest_fd);
 		pair->dest_fd = -1;
-
-		free(pair->dest_name);
-		return true;
+		goto error;
 	}
 #elif !defined(TUKLIB_DOSLIKE)
 	else if (try_sparse && opt_mode == MODE_DECOMPRESS) {
@@ -975,6 +969,10 @@ io_open_dest_real(file_pair *pair)
 #endif
 
 	return false;
+
+error:
+	free(pair->dest_name);
+	return true;
 }
 
 

--- a/src/xz/file_io.h
+++ b/src/xz/file_io.h
@@ -55,6 +55,12 @@ typedef struct {
 	/// File descriptor of the target file
 	int dest_fd;
 
+#ifndef TUKLIB_DOSLIKE
+	/// File descriptor of the directory of the target file (which is
+	/// also the directory of the source file)
+	int dir_fd;
+#endif
+
 	/// True once end of the source file has been detected.
 	bool src_eof;
 
@@ -180,3 +186,12 @@ extern bool io_pread(file_pair *pair, io_buf *buf, size_t size, uint64_t pos);
 /// \return     On success, false is returned. On error, error message
 ///             is printed and true is returned.
 extern bool io_write(file_pair *pair, const io_buf *buf, size_t size);
+
+
+/// \brief      Synchronizes the destination file to permanent storage
+///
+/// \param      pair    File pair having the destination file open for writing
+///
+/// \return     On success, false is returned. On error, error message
+///             is printed and true is returned.
+extern bool io_sync_dest(file_pair *pair);

--- a/src/xz/message.c
+++ b/src/xz/message.c
@@ -1069,7 +1069,8 @@ message_help(bool long_help)
 		e |= tuklib_wrapf(stdout, &wrap2,
 			"    --block-size=%s\v%s\r"
 			"    --block-list=%s\v%s\r"
-			"    --flush-timeout=%s\v%s",
+			"    --flush-timeout=%s\v%s\r"
+			"    --synchronous\v%s",
 			_("SIZE"),
 			W_("start a new .xz block after every SIZE bytes "
 				"of input; use this to set the block size "
@@ -1084,7 +1085,10 @@ message_help(bool long_help)
 			W_("when compressing, if more than NUM "
 				"milliseconds has passed since the previous "
 				"flush and reading more input would block, "
-				"all pending data is flushed out"));
+				"all pending data is flushed out"),
+			W_("synchronize the output file to the storage device "
+				 "after successful compression, "
+				 "decompression, or flushing"));
 
 		e |= tuklib_wrapf(stdout, &wrap2,
 			"    --memlimit-compress=%1$s\n"

--- a/src/xz/sandbox.c
+++ b/src/xz/sandbox.c
@@ -226,7 +226,9 @@ sandbox_init(void)
 	// rights because files are created with open() using O_EXCL and
 	// without O_TRUNC.
 	//
-	// LANDLOCK_ACCESS_FS_READ_DIR is included here to get a clear error
+	// LANDLOCK_ACCESS_FS_READ_DIR is required when using --synchronous.
+	//
+	// LANDLOCK_ACCESS_FS_READ_DIR is also helpful to show a clear error
 	// message if xz is given a directory name. Without this permission
 	// the message would be "Permission denied" but with this permission
 	// it's "Is a directory, skipping". It could be worked around with

--- a/src/xz/xz.1
+++ b/src/xz/xz.1
@@ -1039,6 +1039,41 @@ is unsuitable for decompressing the stream in real time due to how
 .B xz
 does buffering.
 .TP
+.B \-\-synchronous
+After successful compression or decompression,
+synchronize the target file to the storage device.
+The synchronization is done before possibly removing the source file,
+thus at least one of the two files should exist after a system crash.
+.IP ""
+On POSIX systems,
+also the directory containing the file is synchronized
+.BR "except when writing to standard output".
+If the directory isn't synchronized,
+it's possible that the directory entry for the file won't exist after a crash
+even if the file itself has been synchronized.
+A workaround is to create an empty file first and synchronize the directory.
+An example using
+.BR sync (1)
+from GNU coreutils:
+.RS
+.IP ""
+.nf
+.ft CR
+touch foo/bar/target.xz
+sync foo/bar
+sometool | xz --synchronous > foo/bar/target.xz
+.ft R
+.fi
+.RE
+.IP ""
+If
+.B \-\-synchronous
+is used together with
+.BR \-\-flush\-timeout ,
+the file is also synchronized after every flush.
+This way all the data until the most recent flush
+should be recoverable after a system crash.
+.TP
 .BI \-\-memlimit\-compress= limit
 Set a memory usage limit for compression.
 If this option is specified multiple times,


### PR DESCRIPTION
xz's default behavior is to delete the input file after successful compression or decompression (unless writing to standard output). If the system crashes soon after the deletion, it is possible that the newly written file has not yet hit the disk while the previous delete operation might have. In that case neither the original file nor the written file is available.

The `--synchronous` option makes xz call `fsync()` on the file and possibly the directory where the file was created. A similar option was added to GNU gzip 1.7 in 2016.
