### PR TITLE
Build: Add support for `gl_REPLACE_GETOPT_ALWAYS` in getopt.m4

### DIFF
--- a/m4/getopt.m4
+++ b/m4/getopt.m4
@@ -16,6 +16,10 @@ AC_DEFUN([gl_FUNC_GETOPT_GNU],
 [
   AC_REQUIRE([gl_GETOPT_CHECK_HEADERS])
 
+  dnl Other modules can request the gnulib implementation of the getopt
+  dnl functions unconditionally, by defining gl_REPLACE_GETOPT_ALWAYS.
+  m4_ifdef([gl_REPLACE_GETOPT_ALWAYS], [gl_replace_getopt=yes], [])
+
   if test -n "$gl_replace_getopt"; then
     gl_GETOPT_SUBSTITUTE
   fi


### PR DESCRIPTION
Gnulib supports forcing the replacement of getopt & getopt_long, but that was removed from the in-tree simplified getopt.m4. This is useful for building for targets with broken getopt_long implementations.