### PR TITLE
tuklib_physmem: Silence -Wsign-conversion on AIX.

### DIFF
--- a/src/common/tuklib_physmem.c
+++ b/src/common/tuklib_physmem.c
@@ -148,7 +148,7 @@ tuklib_physmem(void)
 			ret += entries[i].end - entries[i].start + 1;
 
 #elif defined(TUKLIB_PHYSMEM_AIX)
-	ret = _system_configuration.physmem;
+	ret = (uint64_t)_system_configuration.physmem;
 
 #elif defined(TUKLIB_PHYSMEM_SYSCONF)
 	const long pagesize = sysconf(_SC_PAGESIZE);


### PR DESCRIPTION
On AIX:

```
$ ./configure && make
[...]
../common/tuklib_physmem.c:151:8: warning: conversion to 'uint64_t' {aka 'long long unsigned int'} from 'long long int' may change the sign of the result [-Wsign-conversion]
  151 |  ret = _system_configuration.physmem;
      |        ^~~~~~~~~~~~~~~~~~~~~
mv -f .deps/liblzma_la-tuklib_physmem.Tpo .deps/liblzma_la-tuklib_physmem.Plo
```

This is harmless, but since the warning is enabled by ./configure if available I figured you would want it fixed.

