### PR TITLE
liblzma: Add LoongArch BCJ filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -935,6 +935,7 @@ set(SIMPLE_FILTERS
     ia64
     sparc
     riscv
+    loongarch
 )
 
 # The SUPPORTED_FILTERS are shared between Encoders and Decoders

--- a/build-aux/ci_build.bash
+++ b/build-aux/ci_build.bash
@@ -197,7 +197,7 @@ then
 
 		cd "$DEST_DIR"
 
-		add_to_filter_list "$BCJ" ",x86,powerpc,ia64,arm,armthumb,arm64,sparc,riscv"
+		add_to_filter_list "$BCJ" ",x86,powerpc,ia64,arm,armthumb,arm64,sparc,riscv,loongarch"
 		add_to_filter_list "$DELTA" ",delta"
 
 		add_extra_option "$ENCODERS" "--enable-encoders=$FILTER_LIST" "--disable-encoders"
@@ -227,7 +227,7 @@ then
 	cmake)
 		cd "$DEST_DIR"
 
-		add_to_filter_list "$BCJ" ";x86;powerpc;ia64;arm;armthumb;arm64;sparc;riscv"
+		add_to_filter_list "$BCJ" ";x86;powerpc;ia64;arm;armthumb;arm64;sparc;riscv;loongarch"
 		add_to_filter_list "$DELTA" ";delta"
 
 		add_extra_option "$THREADS" "-DXZ_THREADS=yes" "-DXZ_THREADS=no"

--- a/configure.ac
+++ b/configure.ac
@@ -78,8 +78,8 @@ fi
 # Filters #
 ###########
 
-m4_define([SUPPORTED_FILTERS], [lzma1,lzma2,delta,x86,powerpc,ia64,arm,armthumb,arm64,sparc,riscv])dnl
-m4_define([SIMPLE_FILTERS], [x86,powerpc,ia64,arm,armthumb,arm64,sparc,riscv])
+m4_define([SUPPORTED_FILTERS], [lzma1,lzma2,delta,x86,powerpc,ia64,arm,armthumb,arm64,sparc,riscv,loongarch])dnl
+m4_define([SIMPLE_FILTERS], [x86,powerpc,ia64,arm,armthumb,arm64,sparc,riscv,loongarch])
 m4_define([LZ_FILTERS], [lzma1,lzma2])
 
 m4_foreach([NAME], [SUPPORTED_FILTERS],

--- a/src/liblzma/api/lzma/bcj.h
+++ b/src/liblzma/api/lzma/bcj.h
@@ -57,6 +57,10 @@
  */
 #define LZMA_FILTER_RISCV       LZMA_VLI_C(0x0B)
 
+/**
+ * \brief       Filter for LoongArch binaries
+ */
+#define LZMA_FILTER_LOONGARCH   LZMA_VLI_C(0x47BEC794C61203)
 
 /**
  * \brief       Options for BCJ filters
@@ -193,3 +197,34 @@ extern LZMA_API(size_t) lzma_bcj_x86_encode(
  */
 extern LZMA_API(size_t) lzma_bcj_x86_decode(
 		uint32_t start_offset, uint8_t *buf, size_t size) lzma_nothrow;
+
+
+/**
+ * \brief       Raw LoongArch BCJ encoder
+ *
+ * This is for special use cases only.
+ *
+ * \param       start_offset  The lowest 32 bits of the offset in the
+ *                            executable being filtered. For the LoongArch
+ *                            filter, this must be a multiple of four.
+ * \param       buf           Buffer to be filtered in place
+ * \param       size          Size of the buffer
+ *
+ * \return      Number of bytes that were processed in `buf`. This is at most
+ *              `size`. With the LoongArch filter, the return value is always
+ *              a multiple of 4, and at most 3 bytes are left unfiltered.
+ *
+ * \since       5.8.1alpha
+ */
+extern LZMA_API(size_t) lzma_bcj_loongarch_encode(
+	uint32_t start_offset, uint8_t *buf, size_t size) lzma_nothrow;
+
+/**
+* \brief       Raw LoongArch BCJ decoder
+*
+* See lzma_bcj_loongarch_encode().
+*
+* \since       5.8.1alpha
+*/
+extern LZMA_API(size_t) lzma_bcj_loongarch_decode(
+	uint32_t start_offset, uint8_t *buf, size_t size) lzma_nothrow;

--- a/src/liblzma/common/filter_common.c
+++ b/src/liblzma/common/filter_common.c
@@ -130,6 +130,15 @@ static const struct {
 		.changes_size = false,
 	},
 #endif
+#if defined(HAVE_ENCODER_LOONGARCH) || defined(HAVE_DECODER_LOONGARCH)
+	{
+		.id = LZMA_FILTER_LOONGARCH,
+		.options_size = sizeof(lzma_options_bcj),
+		.non_last_ok = true,
+		.last_ok = false,
+		.changes_size = false,
+	},
+#endif
 #if defined(HAVE_ENCODER_DELTA) || defined(HAVE_DECODER_DELTA)
 	{
 		.id = LZMA_FILTER_DELTA,

--- a/src/liblzma/common/filter_decoder.c
+++ b/src/liblzma/common/filter_decoder.c
@@ -128,6 +128,14 @@ static const lzma_filter_decoder decoders[] = {
 		.props_decode = &lzma_simple_props_decode,
 	},
 #endif
+#ifdef HAVE_DECODER_LOONGARCH
+	{
+		.id = LZMA_FILTER_LOONGARCH,
+		.init = &lzma_simple_loongarch_decoder_init,
+		.memusage = NULL,
+		.props_decode = &lzma_simple_props_decode,
+	},
+#endif
 #ifdef HAVE_DECODER_DELTA
 	{
 		.id = LZMA_FILTER_DELTA,

--- a/src/liblzma/common/filter_encoder.c
+++ b/src/liblzma/common/filter_encoder.c
@@ -168,6 +168,16 @@ static const lzma_filter_encoder encoders[] = {
 		.props_encode = &lzma_simple_props_encode,
 	},
 #endif
+#ifdef HAVE_ENCODER_LOONGARCH
+	{
+		.id = LZMA_FILTER_LOONGARCH,
+		.init = &lzma_simple_loongarch_encoder_init,
+		.memusage = NULL,
+		.block_size = NULL,
+		.props_size_get = &lzma_simple_props_size,
+		.props_encode = &lzma_simple_props_encode,
+	},
+#endif
 #ifdef HAVE_ENCODER_DELTA
 	{
 		.id = LZMA_FILTER_DELTA,

--- a/src/liblzma/common/string_conversion.c
+++ b/src/liblzma/common/string_conversion.c
@@ -258,7 +258,9 @@ static const char *parse_options(const char **const str, const char *str_end,
 		|| defined(HAVE_ENCODER_SPARC) \
 		|| defined(HAVE_DECODER_SPARC) \
 		|| defined(HAVE_ENCODER_RISCV) \
-		|| defined(HAVE_DECODER_RISCV)
+		|| defined(HAVE_DECODER_RISCV) \
+		|| defined(HAVE_ENCODER_LOONGARCH) \
+		|| defined(HAVE_DECODER_LOONGARCH)
 static const option_map bcj_optmap[] = {
 	{
 		.name = "start",
@@ -523,6 +525,11 @@ static const struct {
 
 #if defined(HAVE_ENCODER_RISCV) || defined(HAVE_DECODER_RISCV)
 	{ "riscv",        sizeof(lzma_options_bcj),   LZMA_FILTER_RISCV,
+	  &parse_bcj,     bcj_optmap, 1, 1, true },
+#endif
+
+#if defined(HAVE_ENCODER_LOONGARCH) || defined(HAVE_DECODER_LOONGARCH)
+	{ "loongarch",        sizeof(lzma_options_bcj),   LZMA_FILTER_LOONGARCH,
 	  &parse_bcj,     bcj_optmap, 1, 1, true },
 #endif
 

--- a/src/liblzma/liblzma_generic.map
+++ b/src/liblzma/liblzma_generic.map
@@ -135,4 +135,6 @@ global:
 	lzma_bcj_riscv_decode;
 	lzma_bcj_x86_encode;
 	lzma_bcj_x86_decode;
+	lzma_bcj_loongarch_encode;
+	lzma_bcj_loongarch_decode;
 } XZ_5.6.0;

--- a/src/liblzma/liblzma_linux.map
+++ b/src/liblzma/liblzma_linux.map
@@ -150,4 +150,6 @@ global:
 	lzma_bcj_riscv_decode;
 	lzma_bcj_x86_encode;
 	lzma_bcj_x86_decode;
+	lzma_bcj_loongarch_encode;
+	lzma_bcj_loongarch_decode;
 } XZ_5.6.0;

--- a/src/liblzma/simple/Makefile.inc
+++ b/src/liblzma/simple/Makefile.inc
@@ -49,3 +49,7 @@ endif
 if COND_FILTER_RISCV
 liblzma_la_SOURCES += simple/riscv.c
 endif
+
+if COND_FILTER_LOONGARCH
+liblzma_la_SOURCES += simple/loongarch.c
+endif

--- a/src/liblzma/simple/loongarch.c
+++ b/src/liblzma/simple/loongarch.c
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: 0BSD
+
+///////////////////////////////////////////////////////////////////////////////
+//
+/// \file       loongarch.c
+/// \brief      Filter for loongarch binaries
+///
+/// This converts loongarch relative addresses in the BL, PCALAU12I. PCADDU18I
+/// immediates to absolute values to increase redundancy of loongarch code.
+///
+/// There are many other PC-relative instrutions, including PCADDI, PCADDU12I
+/// AND B, converting them was tested but they are not very useful, most of
+/// them is not used for functions calls, even if they do, their range are
+/// usually too small so encoding them usually reduce the redundancy.
+//
+//  Authors:    Lasse Collin
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include "simple_private.h"
+
+// This macro checks multiple conditions:
+// (1) inst2 is JIRL
+// (2) JIRL's rj equals to PCADDU18I's rd
+// (3) JIRL's rd = $ra/$zero
+// These conditions could be found in laelf.adoc
+// we use them to further reduce false-positives.
+#define NOT_PCADDU18I_PAIR(pcaddu18i, jirl) \
+	(((jirl >> 26) != 0x13) \
+	|| ((pcaddu18i & 0x1F) != ((jirl >> 5) & 0x1F)) \
+	|| ((jirl & 0x1F) != 0x1 && (jirl & 0x1F) != 0x0))
+
+static size_t
+loongarch_code(void *simple_ptr, uint32_t now_pos, bool is_encoder,
+		uint8_t *buffer, size_t size)
+{
+	if (size < 12)
+		return 0;
+
+	size -= 12;
+
+	size_t i;
+
+	for (i = 0; i <= size; i += 4) {
+		uint32_t pc = (uint32_t)(now_pos + i + 4);
+		uint32_t inst = read32le(buffer + i + 4);
+
+		if ((inst >> 26) == 0x15) {
+			// BL instruction:
+			// The full 26-bit immediate is converted.
+			// The range is +/-128 MiB.
+			//
+			// Using the full range helps quite a lot with
+			// big executables. Smaller range would reduce false
+			// positives in non-code sections of the input though
+			// so this is a compromise that slightly favors big
+			// files. With the full range, only six bits of the 32
+			// need to match to trigger a conversion.
+			const uint32_t src = ((inst & 0x3FF) << 16)
+					| ((inst & 0x3FFFFFF) >> 10);
+
+			// We use previous instruction of the BL to reduce
+			// false positives while filtering non-code buffer,
+			// the previous instructions we use below are get
+			// by analyze loongarch executables and libraries.
+			uint32_t prev_inst = read32le(buffer + i);
+
+			// The instructions below are (in opcode order):
+			// 1. OR ~ LD.WU
+			// 2. BEQZ, BNEZ, B, BL
+			// Only if prev_inst are in these instructions,
+			// we'll convert BL's immediate.
+			if ((prev_inst - 0x00150000) > 0x2A800000 - 0x00150000
+				&& (prev_inst & 0xE8000000) != 0x40000000)
+				continue;
+
+			inst = 0x54000000;
+
+			pc >>= 2;
+			if (!is_encoder)
+				pc = 0U - pc;
+
+			const uint32_t dest = src + pc;
+			inst |= (dest & 0xFFFF) << 10;
+			inst |= (dest & 0x3FF0000) >> 16;
+			write32le(buffer + i + 4, inst);
+
+		} else if ((inst >> 25) == 0xC) {
+			// PCADDI instruction:
+			// We use the previous instruction again to avoid
+			// false-positives.
+			const uint32_t src = (inst >> 5) & 0xFFFFF;
+			inst &= 0x1800001F;
+
+			uint32_t prev_inst = read32le(buffer + i);
+
+			if ((prev_inst - 0x00150000) > 0x2A800000 - 0x00150000
+				&& (prev_inst & 0xE8000000) != 0x40000000)
+				continue;
+
+			pc >>= 2;
+			if (!is_encoder)
+				pc = 0U - pc;
+
+			const uint32_t dest = src + pc;
+			inst |= (dest & 0xFFFFF) << 5;
+			inst |= (0U - (dest & 0x80000)) & 0x1000000;
+			write32le(buffer + i + 4, inst);
+
+		} else if ((inst >> 25) == 0xD) {
+			// PCALAU12I instruction:
+			// Only values in range +/-512MB are converted.
+			//
+			// Similar to ARM64's ADRP instruction, using
+			// less than the full range reduces falses
+			// positives on non-code sections of the input.
+			const uint32_t src = ((inst >> 5) & 0xFFFFF);
+
+			if ((src + 0x20000) & 0xC0000)
+				continue;
+
+			inst &= 0x1A00001F;
+
+			pc >>= 12;
+			if (!is_encoder)
+				pc = 0U - pc;
+
+			const uint32_t dest = src + pc;
+			inst |= (dest & 0x3FFFF) << 5;
+			inst |= (0U - (dest & 0x20000)) & 0x1800000;
+			write32le(buffer + i + 4, inst);
+
+		} else if ((inst >> 25) == 0xF) {
+			// PCADDU18I + JIRL pair
+			// According to laelf.adoc and elfnn-loongarch.c in
+			// binutils this instruction pair is used for medium
+			// code model only, so detect them as a whole to reduce
+			// false-positives. And because the original PCADDU18I
+			// shift the immediate by 18-bit and sign-extend, so we
+			// have to use uint64_t to store address.
+			//
+			// Also, due to all loongarch instrcutions are 4 bytes
+			// long, we could just shift the pc by 2 bits instead
+			// of shift JIRL or PCADDU18I's immediate by 18 or
+			// 2 bits, so that the whole address would fit into
+			// 36 bits instead of 38 bits.
+			uint32_t inst2 = read32le(buffer + i + 8);
+			uint64_t addr = 0;
+
+			if (is_encoder) {
+				addr = (((uint64_t)inst >> 5) & 0xFFFFF) << 16;
+				if (addr & 0x800000000)
+					addr |= 0xFFFFFFF000000000;
+
+				if (NOT_PCADDU18I_PAIR(inst, inst2))
+					continue;
+
+				uint64_t inst2_addr =
+					((uint64_t)inst2 >> 10 & 0xFFFF);
+
+				// Sign-extend the 16-bit immediate in JIRL.
+				if (inst2_addr & 0x8000)
+					inst2_addr |= 0xFFFFFFFFFFFF0000;
+
+				addr += inst2_addr;
+
+				// Skipping if addr equals 0 to improve
+				// compress ratio of .o and .a files.
+				if (addr == 0)
+					continue;
+
+				if (addr + (pc >> 2) == 0)
+					addr = 0;
+
+				addr += pc >> 2;
+
+				inst &= 0x1E00001F;
+				inst |= (addr & 0xFFFFF) << 5;
+
+				inst2 &= 0xFC0003FF;
+				inst2 |= ((addr >> 20) & 0xFFFF) << 10;
+
+				write32le(buffer + i + 4, inst);
+				write32le(buffer + i + 8, inst2);
+
+			} else {
+				if (NOT_PCADDU18I_PAIR(inst, inst2))
+					continue;
+
+				addr = ((uint64_t)inst >> 5) & 0xFFFFF |
+					((uint64_t)inst2 >> 10 & 0xFFFF) << 20;
+
+				if (addr & 0x800000000)
+					addr |= 0xFFFFFFF000000000;
+
+				if (addr == 0)
+					continue;
+
+				if (addr == pc >> 2)
+					addr = 0;
+
+				addr -= pc >> 2;
+
+				inst &= 0x1E00001F;
+				inst |= (addr + 0x8000 >> 16 << 5) & 0x1FFFFE0;
+
+				inst2 &= 0xFC0003FF;
+				inst2 |= (addr & 0x3FFFF) << 10;
+
+				write32le(buffer + i + 4, inst);
+				write32le(buffer + i + 8, inst2);
+			}
+		}
+	}
+
+	return i;
+}
+
+
+static lzma_ret
+loongarch_coder_init(lzma_next_coder *next, const lzma_allocator *allocator,
+		const lzma_filter_info *filters, bool is_encoder)
+{
+	return lzma_simple_coder_init(next, allocator, filters,
+			&loongarch_code, 0, 12, 4, is_encoder);
+}
+
+
+#ifdef HAVE_ENCODER_LOONGARCH
+extern lzma_ret
+lzma_simple_loongarch_encoder_init(lzma_next_coder *next,
+		const lzma_allocator *allocator,
+		const lzma_filter_info *filters)
+{
+	return loongarch_coder_init(next, allocator, filters, true);
+}
+
+
+extern LZMA_API(size_t)
+lzma_bcj_loongarch_encode(uint32_t start_offset, uint8_t *buf, size_t size)
+{
+	// start_offset must be a multiple of four.
+	start_offset &= ~UINT32_C(3);
+	return loongarch_code(NULL, start_offset, true, buf, size);
+}
+#endif
+
+
+#ifdef HAVE_DECODER_LOONGARCH
+extern lzma_ret
+lzma_simple_loongarch_decoder_init(lzma_next_coder *next,
+		const lzma_allocator *allocator,
+		const lzma_filter_info *filters)
+{
+	return loongarch_coder_init(next, allocator, filters, false);
+}
+
+
+extern LZMA_API(size_t)
+lzma_bcj_loongarch_decode(uint32_t start_offset, uint8_t *buf, size_t size)
+{
+	// start_offset must be a multiple of four.
+	start_offset &= ~UINT32_C(3);
+	return loongarch_code(NULL, start_offset, false, buf, size);
+}
+#endif

--- a/src/liblzma/simple/simple_coder.h
+++ b/src/liblzma/simple/simple_coder.h
@@ -86,4 +86,13 @@ extern lzma_ret lzma_simple_riscv_decoder_init(lzma_next_coder *next,
 		const lzma_allocator *allocator,
 		const lzma_filter_info *filters);
 
+
+extern lzma_ret lzma_simple_loongarch_encoder_init(lzma_next_coder *next,
+		const lzma_allocator *allocator,
+		const lzma_filter_info *filters);
+
+extern lzma_ret lzma_simple_loongarch_decoder_init(lzma_next_coder *next,
+		const lzma_allocator *allocator,
+		const lzma_filter_info *filters);
+
 #endif

--- a/src/xz/args.c
+++ b/src/xz/args.c
@@ -214,6 +214,7 @@ parse_real(args_info *args, int argc, char **argv)
 		OPT_ARM64,
 		OPT_SPARC,
 		OPT_RISCV,
+		OPT_LOONGARCH,
 		OPT_DELTA,
 		OPT_LZMA1,
 		OPT_LZMA2,
@@ -300,6 +301,7 @@ parse_real(args_info *args, int argc, char **argv)
 		{ "arm64",        optional_argument, NULL,  OPT_ARM64 },
 		{ "sparc",        optional_argument, NULL,  OPT_SPARC },
 		{ "riscv",        optional_argument, NULL,  OPT_RISCV },
+		{ "loongarch",    optional_argument, NULL,  OPT_LOONGARCH },
 		{ "delta",        optional_argument, NULL,  OPT_DELTA },
 
 		// Other options
@@ -519,6 +521,11 @@ parse_real(args_info *args, int argc, char **argv)
 
 		case OPT_RISCV:
 			coder_add_filter(LZMA_FILTER_RISCV,
+					options_bcj(optarg));
+			break;
+
+		case OPT_LOONGARCH:
+			coder_add_filter(LZMA_FILTER_LOONGARCH,
 					options_bcj(optarg));
 			break;
 

--- a/src/xz/list.c
+++ b/src/xz/list.c
@@ -547,12 +547,23 @@ parse_block_header(file_pair *pair, const lzma_index_iter *iter,
 		xfi->memusage_max = bhi->memusage;
 
 	// Determine the minimum XZ Utils version that supports this Block.
+	//   - LoongArch filter needs 5.8.0.
+	//
 	//   - RISC-V filter needs 5.6.0.
 	//
 	//   - ARM64 filter needs 5.4.0.
 	//
 	//   - 5.0.0 doesn't support empty LZMA2 streams and thus empty
 	//     Blocks that use LZMA2. This decoder bug was fixed in 5.0.2.
+	if (xfi->min_version < 50080002U) {
+		for (size_t i = 0; filters[i].id != LZMA_VLI_UNKNOWN; ++i) {
+			if (filters[i].id == LZMA_FILTER_LOONGARCH) {
+				xfi->min_version = 50080002U;
+				break;
+			}
+		}
+	}
+
 	if (xfi->min_version < 50060002U) {
 		for (size_t i = 0; filters[i].id != LZMA_VLI_UNKNOWN; ++i) {
 			if (filters[i].id == LZMA_FILTER_RISCV) {

--- a/src/xz/message.c
+++ b/src/xz/message.c
@@ -1193,6 +1193,7 @@ message_help(bool long_help)
 			"--ia64[=%s]\v%s\r"
 			"--sparc[=%s]\v%s\r"
 			"--riscv[=%s]\v%s\r"
+			"--loongarch[=%s]\v%s\r"
 			"\v%s",
 			_("OPTS"),
 			W_("x86 BCJ filter (32-bit and 64-bit)"),
@@ -1210,6 +1211,8 @@ message_help(bool long_help)
 			W_("SPARC BCJ filter"),
 			_("OPTS"),
 			W_("RISC-V BCJ filter"),
+			_("OPTS"),
+			W_("LoongArch BCJ filter"),
 			W_("Valid OPTS for all BCJ filters:"));
 		e |= tuklib_wrapf(stdout, &wrap3,
 			"start=%s\v%s",

--- a/src/xz/xz.1
+++ b/src/xz/xz.1
@@ -1869,6 +1869,8 @@ and
 \fB\-\-sparc\fR[\fB=\fIoptions\fR]
 .TP
 \fB\-\-riscv\fR[\fB=\fIoptions\fR]
+.TP
+\fB\-\-loongarch\fR[\fB=\fIoptions\fR]
 .PD
 Add a branch/call/jump (BCJ) filter to the filter chain.
 These filters can be used only as a non-last filter
@@ -1928,6 +1930,7 @@ PowerPC;4;Big endian only
 IA-64;16;Itanium
 SPARC;4;
 RISC-V;2;
+LoongArch;4;
 .TE
 .RE
 .RE
@@ -1958,6 +1961,10 @@ is the best.
 .B readelf \-h
 can be used to check if "RVC"
 appears on the "Flags" line.
+.IP \(bu 3
+LoongArch is always 4-byte aligned so
+.B pb=2,lp=2,lc=2
+is the best.
 .IP \(bu 3
 ARM64 is always 4-byte aligned so
 .B pb=2,lp=2,lc=2

--- a/tests/test_compress.sh
+++ b/tests/test_compress.sh
@@ -162,5 +162,6 @@ test_filter ARMTHUMB armthumb
 test_filter ARM64 arm64
 test_filter SPARC sparc
 test_filter RISCV riscv
+test_filter LOONGARCH loongarch
 
 exit 0

--- a/tests/test_files.sh
+++ b/tests/test_files.sh
@@ -91,6 +91,11 @@ do
 			have_feature DECODER_RISCV "$I" || continue
 			;;
 	esac
+	case $I in
+		*/good-1-loongarch-lzma2-*.xz)
+			have_feature DECODER_LOONGARCH "$I" || continue
+			;;
+	esac
 
 	if test -z "$XZ" || "$XZ" $NO_WARN -dc "$I" > /dev/null; then
 		:

--- a/tests/test_filter_flags.c
+++ b/tests/test_filter_flags.c
@@ -50,6 +50,9 @@ static lzma_filter bcj_filters_encoders[] = {
 #ifdef HAVE_ENCODER_RISCV
 	{ LZMA_FILTER_RISCV, NULL },
 #endif
+#ifdef HAVE_ENCODER_LOONGARCH
+	{ LZMA_FILTER_LOONGARCH, NULL },
+#endif
 	{ LZMA_VLI_UNKNOWN, NULL }
 };
 
@@ -82,6 +85,9 @@ static lzma_filter bcj_filters_decoders[] = {
 #endif
 #ifdef HAVE_DECODER_RISCV
 	{ LZMA_FILTER_RISCV, NULL },
+#endif
+#ifdef HAVE_DECODER_LOONGARCH
+	{ LZMA_FILTER_LOONGARCH, NULL },
 #endif
 	{ LZMA_VLI_UNKNOWN, NULL }
 };

--- a/tests/test_filter_str.c
+++ b/tests/test_filter_str.c
@@ -518,6 +518,9 @@ static const char supported_encoders[][9] = {
 #ifdef HAVE_ENCODER_RISCV
 	"riscv",
 #endif
+#ifdef HAVE_ENCODER_LOONGARCH
+	"loongarch",
+#endif
 #ifdef HAVE_ENCODER_DELTA
 	"delta",
 #endif
@@ -549,6 +552,9 @@ static const char supported_decoders[][9] = {
 #ifdef HAVE_DECODER_RISCV
 	"riscv",
 #endif
+#ifdef HAVE_DECODER_LOONGARCH
+	"loongarch",
+#endif
 #ifdef HAVE_DECODER_DELTA
 	"delta",
 #endif
@@ -579,6 +585,9 @@ static const char supported_filters[][9] = {
 #endif
 #if defined(HAVE_ENCODER_RISCV) || defined(HAVE_DECODER_RISCV)
 	"riscv",
+#endif
+#if defined(HAVE_ENCODER_LOONGARCH) || defined(HAVE_DECODER_LOONGARCH)
+	"loongarch",
 #endif
 #if defined(HAVE_ENCODER_DELTA) || defined(HAVE_DECODER_DELTA)
 	"delta",


### PR DESCRIPTION
This patch adds LoongArch BCJ filter support, it has been tested on real Loongson hardware & QEMU.

It's mostly refer the arm64's filter, converts BL/PCALAU12I only, other BCJ instructions was also tested but they do not have positive effet on redundancy. The PCALAU12I's range is also limited to +/-512MB to reduce false positives.

However, when testing BCJ filter on binaries with debug info, the compress ratio significant worse than use LZMA2 only, It's majority due to many false positives of BL instructions, so I've add a if-statement in BL part that only if the previous instructions of BL is in a range of instructions we selected, we'll convert it's immediate to absolute address, or we'll just ignores it. These instructions were derived from analyzing LoongArch architecture's libraries and executables.

This optimize could largely improves compress ratio when dealing with this kinds of libraries or executables. But this optimize relies on global varibales, I don't sure whether it's reliable in multithread environment. Currently, an one-hour test on Loongson 3C6000(16C/32T) shows no data corruption. It's still a very naive attempt, so it would be much appreciated if you could provide some feedback.

Also, I used 0x0C as this filter's ID, but it's just a temporary path to test the filter.

Related: https://github.com/loongson-community/discussions/issues/78