### PR TITLE
Add License variable to pkg-config file

### DIFF
--- a/src/liblzma/liblzma.pc.in
+++ b/src/liblzma/liblzma.pc.in
@@ -14,3 +14,4 @@ Cflags: -I${includedir}
 Cflags.private: -DLZMA_API_STATIC
 Libs: -L${libdir} -llzma
 Libs.private: @PTHREAD_CFLAGS@ @LIBS@
+License: 0BSD


### PR DESCRIPTION
The pkg-config file has License variable that allows you to set the license for the software.
This sets '0BSD' as defined in SPDX to License.

Ref: https://github.com/pkgconf/pkgconf/blob/master/man/pc.5#L116