### PR TITLE
Release resources even for non-debug builds.

### DIFF
--- a/src/xz/args.c
+++ b/src/xz/args.c
@@ -905,11 +905,9 @@ args_parse(args_info *args, int argc, char **argv)
 }
 
 
-#ifndef NDEBUG
 extern void
 args_free(void)
 {
 	free(opt_block_list);
 	return;
 }
-#endif

--- a/src/xz/coder.c
+++ b/src/xz/coder.c
@@ -1456,7 +1456,6 @@ coder_run(const char *filename)
 }
 
 
-#ifndef NDEBUG
 extern void
 coder_free(void)
 {
@@ -1473,4 +1472,3 @@ coder_free(void)
 	lzma_end(&strm);
 	return;
 }
-#endif

--- a/src/xz/coder.h
+++ b/src/xz/coder.h
@@ -95,10 +95,8 @@ extern void coder_set_compression_settings(void);
 /// Compress or decompress the given file
 extern void coder_run(const char *filename);
 
-#ifndef NDEBUG
 /// Free the memory allocated for the coder and kill the worker threads.
 extern void coder_free(void);
-#endif
 
 /// Create filter chain from string
 extern void coder_add_filters_from_str(const char *filter_str);

--- a/src/xz/main.c
+++ b/src/xz/main.c
@@ -339,10 +339,8 @@ main(int argc, char **argv)
 	}
 #endif
 
-#ifndef NDEBUG
 	coder_free();
 	args_free();
-#endif
 
 	// If we have got a signal, raise it to kill the program instead
 	// of calling tuklib_exit().

--- a/src/xzdec/xzdec.c
+++ b/src/xzdec/xzdec.c
@@ -479,11 +479,7 @@ main(int argc, char **argv)
 		} while (++optind < argc);
 	}
 
-#ifndef NDEBUG
-	// Free the memory only when debugging. Freeing wastes some time,
-	// but allows detecting possible memory leaks with Valgrind.
 	lzma_end(&strm);
-#endif
 
 	tuklib_exit(EXIT_SUCCESS, EXIT_FAILURE, display_errors);
 }


### PR DESCRIPTION
This change makes the applications actually free the associated resources even for non-debug builds.

Not all platforms implement shared libraries in the way that the library allocator links to the parent application's heap. Not releasing resources can thus lead to actual memory leaks, which can be hundreds of megabytes in case of xz tools.