### PR TITLE
tuklib_integer: Autodetect support for unaligned access on loongarch.

### DIFF
--- a/m4/tuklib_integer.m4
+++ b/m4/tuklib_integer.m4
@@ -78,7 +78,7 @@ if test "x$enable_unaligned_access" = xauto ; then
 		i?86|x86_64|powerpc|powerpc64|powerpc64le)
 			enable_unaligned_access=yes
 			;;
-		arm*|aarch64*|riscv*)
+		arm*|aarch64*|riscv*|loongarch*)
 			# On 32-bit and 64-bit ARM, GCC and Clang
 			# #define __ARM_FEATURE_UNALIGNED if
 			# unaligned access is supported.


### PR DESCRIPTION
-mstrict-align is also supported on loongarch architecture