### PR TITLE
tuklib_integer: Autodetect support for unaligned access on loongarch.

### DIFF
--- a/m4/tuklib_integer.m4
+++ b/m4/tuklib_integer.m4
@@ -78,7 +78,7 @@ if test "x$enable_unaligned_access" = xauto ; then
 		i?86|x86_64|powerpc|powerpc64|powerpc64le)
 			enable_unaligned_access=yes
 			;;
-		arm*|aarch64*|riscv*)
+		arm*|aarch64*|riscv*|loongarch*)
 			# On 32-bit and 64-bit ARM, GCC and Clang
 			# #define __ARM_FEATURE_UNALIGNED if
 			# unaligned access is supported.
@@ -101,7 +101,8 @@ if test "x$enable_unaligned_access" = xauto ; then
 			AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 #if !defined(__ARM_FEATURE_UNALIGNED) \
 		&& !defined(__riscv_misaligned_fast) \
-		&& !defined(_MSC_VER)
+		&& !defined(_MSC_VER) \
+		&& !defined(__loongarch__) 
 compile error
 #endif
 int main(void) { return 0; }


### PR DESCRIPTION
-mstrict-align is also supported on loongarch architecture

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111555
https://github.com/llvm/llvm-project/pull/85350
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/arch/loongarch/Kconfig?h=v6.12.35#n536

