### PR TITLE
CMake: Guard script configure_file() calls with ENABLE_SCRIPTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2405,20 +2405,20 @@ xzdiff, xzgrep, xzmore, xzless, and their symlinks" ON)
     set(xz "xz")
     set(POSIX_SHELL "${XZ_POSIX_SHELL}")
 
-    foreach(S xzdiff xzgrep xzmore xzless)
-        configure_file("src/scripts/${S}.in" "${S}"
-               @ONLY
-               NEWLINE_STYLE LF
-               FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                                GROUP_READ GROUP_EXECUTE
-                                WORLD_READ WORLD_EXECUTE)
+    if(ENABLE_SCRIPTS)
+        foreach(S xzdiff xzgrep xzmore xzless)
+            configure_file("src/scripts/${S}.in" "${S}"
+                   @ONLY
+                   NEWLINE_STYLE LF
+                   FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                                    GROUP_READ GROUP_EXECUTE
+                                    WORLD_READ WORLD_EXECUTE)
 
-        if(ENABLE_SCRIPTS)
             install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/${S}"
                     DESTINATION "${CMAKE_INSTALL_BINDIR}"
                     COMPONENT scripts_Runtime)
-        endif()
-    endforeach()
+        endforeach()
+    endif()
 
     unset(xz)
     unset(POSIX_SHELL)


### PR DESCRIPTION
The configure_file() calls for xzdiff, xzgrep, xzmore, and xzless were running unconditionally within the if(UNIX) block, even when ENABLE_SCRIPTS was OFF. This would cause a build failure if the src/scripts/*.in files were not present (we do that since we want to only build liblzma and link it to our application and want to minimize vendored code size)

Move the foreach loop inside the existing `if(ENABLE_SCRIPTS)` guard so that configure_file() is only called when scripts are actually being built and installed.