### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       ########################
       # Install Dependencies #
@@ -164,7 +164,7 @@ jobs:
         run: ./build-aux/ci_build.bash -b ${{ matrix.build_system }} -d small -p test -n small
 
       # Attempt to upload the test logs as artifacts if any step has failed
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ failure() }}
         with:
           name: ${{ matrix.os }} ${{ matrix.build_system }} Test Logs

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -48,7 +48,7 @@ jobs:
         report-ooms: true
 
     - name: Upload Crash
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure() && steps.build.outcome == 'success'
       with:
         name: ${{ matrix.sanitizer }}-artifacts

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ jobs:
   coverity:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/dragonflybsd.yml
+++ b/.github/workflows/dragonflybsd.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     name: DragonFly BSD
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Test in DragonFly BSD
         id: test

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -34,7 +34,7 @@ jobs:
     name: FreeBSD
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Test in FreeBSD
         uses: vmactions/freebsd-vm@670398e4236735b8b65805c3da44b7a511fb8b27 #v1.3.0

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure Win32
         run: >

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -78,7 +78,7 @@ jobs:
         # text file and will not match the output from xzgrep.
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: CMake (full, shared)
         run: |
@@ -137,7 +137,7 @@ jobs:
           make -j"$(nproc)" check
 
       # Upload the test logs as artifacts if any step has failed.
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: test-logs-${{ matrix.sys }}

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     name: NetBSD
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Test in NetBSD
         id: test

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     name: OpenBSD
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Test in OpenBSD
         uses: vmactions/openbsd-vm@2e29de1eb150dfe1c9c97b84ff2b7896f14ca690 #v1.2.5

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     name: Solaris
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Test in Solaris
         uses: vmactions/solaris-vm@47bea106d03acaf91084e52548ee460556011602 #v1.1.8


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | ci.yml, coverity.yml, dragonflybsd.yml, freebsd.yml, msvc.yml, msys2.yml, netbsd.yml, openbsd.yml, solaris.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/upload-artifact/releases/tag/v7) | [Release](https://github.com/actions/upload-artifact/releases/tag/v7) | ci.yml, cifuzz.yml, msys2.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting June 2nd, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: June 2nd, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/checkout** (v4 → v6): Major version upgrade — review the [release notes](https://github.com/actions/checkout/releases) for breaking changes
- **actions/upload-artifact** (v4 → v7): Major version upgrade — review the [release notes](https://github.com/actions/upload-artifact/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
