### PR TITLE
xz: Don't fsync directories on QNX

### DIFF
--- a/src/xz/file_io.c
+++ b/src/xz/file_io.c
@@ -493,8 +493,9 @@ io_sync_dest(file_pair *pair)
 		return true;
 	}
 
-#if !defined(TUKLIB_DOSLIKE) && !defined(_AIX)
+#if !defined(TUKLIB_DOSLIKE) && !defined(_AIX) && !defined(__QNX__)
 	// On AIX, this would fail with EBADF.
+        // On QNX, this would fail with EINVAL.
 	if (fsync(pair->dir_fd)) {
 		message_error(_("%s: Synchronizing the directory of "
 				"the file failed: %s"),


### PR DESCRIPTION
On QNX calling fsync on a directory fails with EINVAL. This causes the following test failure:

    $ cat tests/test_suffix.sh.log
    /data/home/root/xz-5.8.2/src/xz/.libs/lt-xz: suffix_temp: Synchronizing the directory of the file failed: Invalid argument
    Failed to decompress a file with a suffix set in raw format
    FAIL test_suffix.sh (exit status: 1)