### PR TITLE
xz: Add overflow check to read_name() buffer doubling

### DIFF
--- a/src/xz/main.c
+++ b/src/xz/main.c
@@ -134,6 +134,9 @@ read_name(const args_info *args)
 		// at least for one character to allow terminating the string
 		// with '\0'.
 		if (pos == size) {
+			if (size > SIZE_MAX / 2) {
+				message_fatal(_("Filename is too long"));
+			}
 			size *= 2;
 			name = xrealloc(name, size);
 		}


### PR DESCRIPTION
`read_name()` in `src/xz/main.c` doubles its filename buffer with `size *= 2` without checking for overflow. If `size` exceeds `SIZE_MAX / 2`, the multiplication wraps to 0 and `xrealloc(name, 0)` can free the buffer while subsequent code writes to it via `name[pos++] = c`.

This adds a check before the doubling that aborts with an error if the buffer has grown beyond `SIZE_MAX / 2`. This addresses the existing FIXME at line 61:

    // FIXME: Maybe we should have some kind of memory usage limit here