### PR TITLE
Fix various man page syntax issues

### DIFF
--- a/po4a/update-po
+++ b/po4a/update-po
@@ -80,6 +80,13 @@ po4a --force --verbose \
 	--copyright-holder="The XZ Utils authors and contributors" \
 	po4a.conf
 
+# Non-ASCII characters in table data can cause groff to merge UTF-8 escapes with
+# internal table markup like [tbl], creating invalid character names. Insert \&
+# (zero-width space) after non-ASCII characters in table data rows (lines
+# containing ;) to prevent this.
+echo "po4a/update-po: Fix syntax issues in generated man pages"
+find man/ -name '*.1' -exec perl -i -CSD -pe '/;/ && s/([^\x00-\x7F])/\1\\&/g' {} +
+
 # Remove the *.po.authors files that were generated above.
 # This way they won't get included in distribution tarballs.
 rm -f -- *.po.authors

--- a/src/xz/xz.1
+++ b/src/xz/xz.1
@@ -770,12 +770,10 @@ This also means that the amount of uncompressed output
 produced per second can vary a lot.
 .IP ""
 The following table summarises the features of the presets:
-.RS
-.RS
 .PP
-.TS
+.TS expand nowarn
 tab(;);
-c c c c c
+c c c c l
 n n n n n.
 Preset;DictSize;CompCPU;CompMem;DecMem
 \-0;256 KiB;0;3 MiB;1 MiB
@@ -789,8 +787,6 @@ Preset;DictSize;CompCPU;CompMem;DecMem
 \-8;32 MiB;6;370 MiB;33 MiB
 \-9;64 MiB;6;674 MiB;65 MiB
 .TE
-.RE
-.RE
 .IP ""
 Column descriptions:
 .RS
@@ -858,12 +854,10 @@ and
 .BR \-6e ,
 respectively.
 That way no two presets are identical.
-.RS
-.RS
 .PP
-.TS
+.TS expand nowarn
 tab(;);
-c c c c c
+c c c c l
 n n n n n.
 Preset;DictSize;CompCPU;CompMem;DecMem
 \-0e;256 KiB;8;4 MiB;1 MiB
@@ -877,8 +871,6 @@ Preset;DictSize;CompCPU;CompMem;DecMem
 \-8e;32 MiB;8;370 MiB;33 MiB
 \-9e;64 MiB;8;674 MiB;65 MiB
 .TE
-.RE
-.RE
 .IP ""
 For example, there are a total of four presets that use
 8\ MiB dictionary, whose order from the fastest to the slowest is
@@ -1905,10 +1897,8 @@ which is better in each situation.
 Different instruction sets have different alignment:
 the executable file must be aligned to a multiple of
 this value in the input data to make the filter work.
-.RS
-.RS
 .PP
-.TS
+.TS expand
 tab(;);
 l n l
 l n l.
@@ -1922,8 +1912,6 @@ IA-64;16;Itanium
 SPARC;4;
 RISC-V;2;
 .TE
-.RE
-.RE
 .IP ""
 Since the BCJ-filtered data is usually compressed with LZMA2,
 the compression ratio may be improved slightly if
@@ -2684,9 +2672,8 @@ and LZMA Utils.
 The most important difference is how dictionary sizes
 are mapped to different presets.
 Dictionary size is roughly equal to the decompressor memory usage.
-.RS
 .PP
-.TS
+.TS expand
 tab(;);
 c c c
 c n n.
@@ -2702,16 +2689,14 @@ Level;xz;LZMA Utils
 \-8;32 MiB;16 MiB
 \-9;64 MiB;32 MiB
 .TE
-.RE
 .PP
 The dictionary size differences affect
 the compressor memory usage too,
 but there are some other differences between
 LZMA Utils and XZ Utils, which
 make the difference even bigger:
-.RS
 .PP
-.TS
+.TS expand
 tab(;);
 c c c
 c n n.
@@ -2727,7 +2712,6 @@ Level;xz;LZMA Utils 4.32.x
 \-8;370 MiB;159 MiB
 \-9;674 MiB;311 MiB
 .TE
-.RE
 .PP
 The default preset level in LZMA Utils is
 .B \-7
@@ -3074,9 +3058,8 @@ and
 .B \-\-extreme
 are useful when customizing LZMA2 presets.
 Here are the relevant parts collected from those two tables:
-.RS
 .PP
-.TS
+.TS expand
 tab(;);
 c c
 n n.
@@ -3091,7 +3074,6 @@ Preset;CompCPU
 \-5e;7
 \-6e;8
 .TE
-.RE
 .PP
 If you know that a file requires
 somewhat big dictionary (for example, 32\ MiB) to compress well,


### PR DESCRIPTION
Debian quality assurance tool Lintian flagged that `man` emits warnings while opening some of the XZ man pages:

    W: xz-utils: groff-message troff:<standard input>:1078: warning: special character 'u0435\[tbl' not defined [usr/share/man/sr/man1/xz.1.gz:1]
    W: xz-utils: groff-message troff:<standard input>:1157: warning: special character 'u044\[tbl' not defined [usr/share/man/uk/man1/xz.1.gz:2]
    W: xz-utils: groff-message troff:<standard input>:1292: warning: special character 'uC74\[tbl' not defined [usr/share/man/ko/man1/xz.1.gz:2]
    W: xz-utils: groff-message troff:<standard input>:1586: warning: special character 'u0414\[tbl' not defined [usr/share/man/sr/man1/xz.1.gz:2]
    W: xz-utils: groff-message troff:<standard input>:1682: warning: special character 'u0434\[tbl' not defined [usr/share/man/uk/man1/xz.1.gz:3]
    W: xz-utils: groff-message troff:<standard input>:1746: warning: special character 'u00\[tbl' not defined [usr/share/man/de/man1/xz.1.gz:1]
    W: xz-utils: groff-message troff:<standard input>:402: warning: special character 'u062\[tbl' not defined [usr/share/man/ar/man1/xz.1.gz:1]
    W: xz-utils: groff-message troff:<standard input>:464: warning: special character 'u0411\[tbl' not defined [usr/share/man/uk/man1/xz.1.gz:1]
    W: xz-utils: groff-message troff:<standard input>:857: warning: special character 'uB82\[tbl' not defined [usr/share/man/ko/man1/xz.1.gz:1]
    W: xz-utils: groff-message troff:<standard input>:991: warning: special character 'u0629\[tbl' not defined [usr/share/man/ar/man1/xz.1.gz:2]

This was reproducible with:

    $ for P in $(find * -name 'xz.1')
    do
     echo $P:"
     LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z $P >/dev/null
    done

    po4a/man/pt_BR/xz.1:
    po4a/man/it/xz.1:
    <standard input>:472: warning: table wider than line length minus indentation
    <standard input>:540: warning: table wider than line length minus indentation
    <standard input>:1177: warning: table wider than line length minus indentation
    po4a/man/fr/xz.1:
    po4a/man/de/xz.1:
    <standard input>:479: warning: table wider than line length minus indentation
    <standard input>:547: warning: table wider than line length minus indentation
    <standard input>:1193: warning: table wider than line length minus indentation
    troff:<standard input>:1746: warning: special character 'u00\[tbl' not defined
    po4a/man/sv/xz.1:
    po4a/man/ko/xz.1:
    troff:<standard input>:857: warning: special character 'uB82\[tbl' not defined
    troff:<standard input>:1292: warning: special character 'uC74\[tbl' not defined
    po4a/man/uk/xz.1:
    troff:<standard input>:464: warning: special character 'u0411\[tbl' not defined
    troff:<standard input>:1157: warning: special character 'u044\[tbl' not defined
    troff:<standard input>:1682: warning: special character 'u0434\[tbl' not defined
    po4a/man/ro/xz.1:
    po4a/man/sr/xz.1:
    troff:<standard input>:1078: warning: special character 'u0435\[tbl' not defined
    troff:<standard input>:1586: warning: special character 'u0414\[tbl' not defined
    po4a/man/ar/xz.1:
    troff:<standard input>:402: warning: special character 'u062\[tbl' not defined
    <standard input>:401: warning: table wider than line length minus indentation
    <standard input>:458: warning: table wider than line length minus indentation
    troff:<standard input>:991: warning: special character 'u0629\[tbl' not defined
    src/xz/xz.1:

The special character issues were because `po4a` is not designed to produce man page output, and it unfortunately generates groff Unicode escapes like '\u0435' followed immediately by '[' in table contexts, causing `groff` to interpret the full string 'u0435[tbl' as a single special character name. Fix this by inserting a zero-width space (\&) after every Unicode escape so that the bracket is treated as literal text instead of part of the character name.

The issues about tables too wider were because some of the translations are too long and can't fit the table column expectations. Fix this by indeting the table less to there is more space in total, and by adjusting columns.

With these fixes `man` no longer emits any warnings.

## Testing

Running `./po4a/update-po`  results in man pages with all syntax issues fixed, e.g.:

<img width="1920" height="826" alt="image" src="https://github.com/user-attachments/assets/3c0c5098-798e-41f1-a2a7-fc960d44f056" />

In addition to the output of the commands above, I also compared the actual visuall output of the resulting man pages. The screenshot below shows as an example how the man page in German has all text intact and table indented a bit less and it continues to render correctly:

<img width="1920" height="486" alt="image" src="https://github.com/user-attachments/assets/832d0bbf-adbb-4a90-97a5-94824b975b9a" />

## Extra info

One could also use these commands to find man page syntax issues:

```
for P in $(find * -name 'xz.1'); do  echo "$P:"; mandoc -T lint $P; done
for P in $(find * -name 'xz.1'); do  echo "$P:"; groff -mandoc -t -ww -z $P; done
for P in $(find * -name 'xz.1'); do  echo "$P:"; groff -mandoc -t -K utf8 -rF0 -rHY=0 -rCHECKSTYLE=10 -ww -z $P; done
```

However they show so many minor issues that it is not worthwhile to fix more than what I already this in this PR.