### PR TITLE
Added better error codes for lzma_code()

### DIFF
--- a/TODO
+++ b/TODO
@@ -56,10 +56,6 @@ Missing features
     Support LZMA_FULL_FLUSH for lzma_stream_decoder() to stop at
     Block and Stream boundaries.
 
-    Error codes from lzma_code() aren't very specific. A more detailed
-    error message (string) could be provided too. It could be returned
-    by a new function or use a currently-reserved member of lzma_stream.
-
     Make it possible to adjust LZMA2 options in the middle of a Block
     so that the encoding speed vs. compression ratio can be optimized
     when the compressed data is streamed over network.

--- a/doc/examples/05_error_messages.c
+++ b/doc/examples/05_error_messages.c
@@ -1,0 +1,120 @@
+/*
+ * This example demonstrates how to retrieve detailed error messages
+ * from lzma_code() when an error occurs.
+ *
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include <stdio.h>
+#include <lzma.h>
+
+int
+main(void)
+{
+	printf("Example 1: Error message for programming error\n");
+	printf("-----------------------------------------------\n\n");
+
+	lzma_stream strm = LZMA_STREAM_INIT;
+	lzma_ret ret;
+
+	// Initialize a valid encoder
+	ret = lzma_easy_encoder(&strm, LZMA_PRESET_DEFAULT, LZMA_CHECK_CRC64);
+	if (ret != LZMA_OK) {
+		fprintf(stderr, "Failed to initialize encoder\n");
+		return 1;
+	}
+
+	// Try to call lzma_code with invalid arguments (NULL next_out with avail_out > 0)
+	// This causes a LZMA_PROG_ERROR
+	strm.next_out = NULL;
+	strm.avail_out = 100;
+
+	ret = lzma_code(&strm, LZMA_RUN);
+	
+	printf("Error code: %d\n", ret);
+	const char *err_msg = lzma_get_error_message(&strm);
+	if (err_msg != NULL) {
+		printf("Error message: %s\n", err_msg);
+	} else {
+		printf("No error message available\n");
+	}
+
+	lzma_end(&strm);
+
+	printf("\n\nExample 2: Error message for format error during decompression\n");
+	printf("---------------------------------------------------------------\n\n");
+
+	lzma_stream strm2 = LZMA_STREAM_INIT;
+	
+	// Initialize the decoder
+	ret = lzma_stream_decoder(&strm2, UINT64_MAX, LZMA_CONCATENATED);
+	if (ret != LZMA_OK) {
+		fprintf(stderr, "Failed to initialize decoder\n");
+		return 1;
+	}
+
+	// Try to decode clearly invalid/corrupted data
+	uint8_t invalid_data[] = { 0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00,  // XZ header
+	                           0xFF, 0xFF, 0xFF, 0xFF, 0xFF };       // Corrupted data
+	strm2.next_in = invalid_data;
+	strm2.avail_in = sizeof(invalid_data);
+	
+	uint8_t output_buffer[100];
+	strm2.next_out = output_buffer;
+	strm2.avail_out = sizeof(output_buffer);
+
+	ret = lzma_code(&strm2, LZMA_RUN);
+	
+	printf("Result code: %d\n", ret);
+	const char *err_msg2 = lzma_get_error_message(&strm2);
+	if (err_msg2 != NULL) {
+		printf("Error message: %s\n", err_msg2);
+	} else {
+		printf("No error message available\n");
+	}
+
+	lzma_end(&strm2);
+
+	printf("\n\nExample 3: Error message is NULL after successful operation\n");
+	printf("-----------------------------------------------------------\n\n");
+
+	lzma_stream strm3 = LZMA_STREAM_INIT;
+	
+	// Initialize the encoder properly
+	ret = lzma_easy_encoder(&strm3, LZMA_PRESET_DEFAULT, LZMA_CHECK_CRC64);
+	if (ret != LZMA_OK) {
+		fprintf(stderr, "Failed to initialize encoder\n");
+		return 1;
+	}
+
+	// Set up input/output buffers
+	uint8_t input_data[] = "Hello, World!";
+	uint8_t output_buffer2[100];
+	
+	strm3.next_in = input_data;
+	strm3.avail_in = sizeof(input_data) - 1;
+	strm3.next_out = output_buffer2;
+	strm3.avail_out = sizeof(output_buffer2);
+
+	ret = lzma_code(&strm3, LZMA_FINISH);
+	
+	if (ret == LZMA_STREAM_END || ret == LZMA_OK) {
+		printf("Encoding succeeded (return code: %d)\n", ret);
+		const char *err_msg3 = lzma_get_error_message(&strm3);
+		if (err_msg3 != NULL) {
+			printf("Error message (should be NULL): %s\n", err_msg3);
+		} else {
+			printf("Error message: NULL (as expected)\n");
+		}
+	} else {
+		printf("Encoding failed with error: %d\n", ret);
+		const char *err_msg3 = lzma_get_error_message(&strm3);
+		if (err_msg3 != NULL) {
+			printf("Error message: %s\n", err_msg3);
+		}
+	}
+
+	lzma_end(&strm3);
+
+	return 0;
+}

--- a/src/liblzma/api/lzma/base.h
+++ b/src/liblzma/api/lzma/base.h
@@ -547,8 +547,17 @@ typedef struct {
 	 * may change.
 	 */
 
-	/** \private     Reserved member. */
-	void *reserved_ptr1;
+	/**
+	 * \brief       Error message string
+	 *
+	 * This member stores a pointer to a detailed error message string
+	 * when lzma_code() returns an error code. The string is valid until
+	 * the next call to lzma_code() or lzma_end(). The application should
+	 * not modify this pointer.
+	 *
+	 * To retrieve the error message, call lzma_get_error_message().
+	 */
+	const char *reserved_ptr1;
 
 	/** \private     Reserved member. */
 	void *reserved_ptr2;
@@ -635,6 +644,29 @@ typedef struct {
  */
 extern LZMA_API(lzma_ret) lzma_code(lzma_stream *strm, lzma_action action)
 		lzma_nothrow lzma_attr_warn_unused_result;
+
+
+/**
+ * \brief       Get error message string
+ *
+ * This function returns a detailed error message string corresponding to
+ * the most recent lzma_code() call. The message provides additional context
+ * about why the error occurred.
+ *
+ * The returned string is valid until the next call to lzma_code() or
+ * lzma_end(). The application must not modify the returned string.
+ *
+ * If no error has occurred or if the error code doesn't have an associated
+ * message, this function returns NULL.
+ *
+ * \param       strm    Pointer to lzma_stream that is at least initialized
+ *                      with LZMA_STREAM_INIT.
+ *
+ * \return      Pointer to a static error message string, or NULL if no
+ *              error message is available.
+ */
+extern LZMA_API(const char *) lzma_get_error_message(const lzma_stream *strm)
+		lzma_nothrow lzma_attr_pure;
 
 
 /**

--- a/src/liblzma/common/common.c
+++ b/src/liblzma/common/common.c
@@ -30,6 +30,39 @@ lzma_version_string(void)
 }
 
 
+////////////////////
+// Error messages //
+///////////////////
+
+// Static error message strings for all error codes
+static const char *error_messages[] = {
+	[LZMA_OK] = NULL,  // No error
+	[LZMA_STREAM_END] = NULL,  // Not an error
+	[LZMA_NO_CHECK] = "Input stream has no integrity check",
+	[LZMA_UNSUPPORTED_CHECK] = "Cannot calculate the requested integrity check",
+	[LZMA_GET_CHECK] = NULL,  // Not an error
+	[LZMA_MEM_ERROR] = "Cannot allocate memory",
+	[LZMA_MEMLIMIT_ERROR] = "Memory usage limit was reached",
+	[LZMA_FORMAT_ERROR] = "File format not recognized",
+	[LZMA_OPTIONS_ERROR] = "Invalid or unsupported options",
+	[LZMA_DATA_ERROR] = "Data is corrupt",
+	[LZMA_BUF_ERROR] = "No progress is possible",
+	[LZMA_PROG_ERROR] = "Programming error",
+	[LZMA_SEEK_NEEDED] = "Request to change the input file position",
+};
+
+
+// Helper function to set the error message in the stream
+static void
+lzma_set_error_message(lzma_stream *strm, lzma_ret ret)
+{
+	if (strm != NULL && ret >= 0 && ret < (int)ARRAY_SIZE(error_messages))
+		strm->reserved_ptr1 = error_messages[ret];
+	else if (strm != NULL)
+		strm->reserved_ptr1 = NULL;
+}
+
+
 ///////////////////////
 // Memory allocation //
 ///////////////////////
@@ -209,21 +242,26 @@ lzma_code(lzma_stream *strm, lzma_action action)
 			|| strm->internal == NULL
 			|| strm->internal->next.code == NULL
 			|| (unsigned int)(action) > LZMA_ACTION_MAX
-			|| !strm->internal->supported_actions[action])
+			|| !strm->internal->supported_actions[action]) {
+		lzma_set_error_message(strm, LZMA_PROG_ERROR);
 		return LZMA_PROG_ERROR;
+		
+	}
 
 	// Check if unsupported members have been set to non-zero or non-NULL,
 	// which would indicate that some new feature is wanted.
-	if (strm->reserved_ptr1 != NULL
-			|| strm->reserved_ptr2 != NULL
+	// Note: reserved_ptr1 is now used for error messages, so we don't check it here.
+	if (strm->reserved_ptr2 != NULL
 			|| strm->reserved_ptr3 != NULL
 			|| strm->reserved_ptr4 != NULL
 			|| strm->reserved_int2 != 0
 			|| strm->reserved_int3 != 0
 			|| strm->reserved_int4 != 0
 			|| strm->reserved_enum1 != LZMA_RESERVED_ENUM
-			|| strm->reserved_enum2 != LZMA_RESERVED_ENUM)
+			|| strm->reserved_enum2 != LZMA_RESERVED_ENUM) {
+		lzma_set_error_message(strm, LZMA_OPTIONS_ERROR);
 		return LZMA_OPTIONS_ERROR;
+	}
 
 	switch (strm->internal->sequence) {
 	case ISEQ_RUN:
@@ -254,29 +292,37 @@ lzma_code(lzma_stream *strm, lzma_action action)
 		// The same action must be used until we return
 		// LZMA_STREAM_END, and the amount of input must not change.
 		if (action != LZMA_SYNC_FLUSH
-				|| strm->internal->avail_in != strm->avail_in)
+				|| strm->internal->avail_in != strm->avail_in) {
+			lzma_set_error_message(strm, LZMA_PROG_ERROR);
 			return LZMA_PROG_ERROR;
+		}
 
 		break;
 
 	case ISEQ_FULL_FLUSH:
 		if (action != LZMA_FULL_FLUSH
-				|| strm->internal->avail_in != strm->avail_in)
+				|| strm->internal->avail_in != strm->avail_in) {
+			lzma_set_error_message(strm, LZMA_PROG_ERROR);
 			return LZMA_PROG_ERROR;
+		}
 
 		break;
 
 	case ISEQ_FINISH:
 		if (action != LZMA_FINISH
-				|| strm->internal->avail_in != strm->avail_in)
+				|| strm->internal->avail_in != strm->avail_in) {
+			lzma_set_error_message(strm, LZMA_PROG_ERROR);
 			return LZMA_PROG_ERROR;
+		}
 
 		break;
 
 	case ISEQ_FULL_BARRIER:
 		if (action != LZMA_FULL_BARRIER
-				|| strm->internal->avail_in != strm->avail_in)
+				|| strm->internal->avail_in != strm->avail_in) {
+			lzma_set_error_message(strm, LZMA_PROG_ERROR);
 			return LZMA_PROG_ERROR;
+		}
 
 		break;
 
@@ -285,6 +331,7 @@ lzma_code(lzma_stream *strm, lzma_action action)
 
 	case ISEQ_ERROR:
 	default:
+		lzma_set_error_message(strm, LZMA_PROG_ERROR);
 		return LZMA_PROG_ERROR;
 	}
 
@@ -372,7 +419,18 @@ lzma_code(lzma_stream *strm, lzma_action action)
 		break;
 	}
 
+	lzma_set_error_message(strm, ret);
 	return ret;
+}
+
+
+extern LZMA_API(const char *)
+lzma_get_error_message(const lzma_stream *strm)
+{
+	if (strm == NULL)
+		return NULL;
+
+	return strm->reserved_ptr1;
 }
 
 
@@ -383,6 +441,7 @@ lzma_end(lzma_stream *strm)
 		lzma_next_end(&strm->internal->next, strm->allocator);
 		lzma_free(strm->internal, strm->allocator);
 		strm->internal = NULL;
+		strm->reserved_ptr1 = NULL;
 	}
 
 	return;

--- a/tests/test_error_messages.c
+++ b/tests/test_error_messages.c
@@ -1,0 +1,143 @@
+/*
+ * Test suite for lzma_get_error_message functionality
+ *
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include "tests.h"
+
+
+static void
+test_error_message_prog_error(void)
+{
+	// Test that LZMA_PROG_ERROR gets an error message
+	lzma_stream strm = LZMA_STREAM_INIT;
+	
+	// Initialize an encoder
+	lzma_ret ret = lzma_easy_encoder(&strm, LZMA_PRESET_DEFAULT, LZMA_CHECK_CRC64);
+	assert_lzma_ret(ret, LZMA_OK);
+
+	// Try to call lzma_code with invalid arguments (NULL next_out)
+	strm.next_out = NULL;
+	strm.avail_out = 100;  // Non-zero avail_out with NULL next_out causes PROG_ERROR
+	
+	ret = lzma_code(&strm, LZMA_RUN);
+	assert_lzma_ret(ret, LZMA_PROG_ERROR);
+	
+	const char *err_msg = lzma_get_error_message(&strm);
+	assert_true(err_msg != NULL);
+	
+	lzma_end(&strm);
+}
+
+
+static void
+test_error_message_format_error(void)
+{
+	// Test that LZMA_FORMAT_ERROR gets an error message
+	lzma_stream strm = LZMA_STREAM_INIT;
+	
+	// Initialize a decoder
+	lzma_ret ret = lzma_stream_decoder(&strm, UINT64_MAX, LZMA_CONCATENATED);
+	assert_lzma_ret(ret, LZMA_OK);
+
+	// Try to decode data that doesn't have valid LZMA format
+	uint8_t invalid_data[] = "Not LZMA data";
+	strm.next_in = invalid_data;
+	strm.avail_in = sizeof(invalid_data);
+	
+	uint8_t output_buffer[100];
+	strm.next_out = output_buffer;
+	strm.avail_out = sizeof(output_buffer);
+
+	ret = lzma_code(&strm, LZMA_RUN);
+	assert_lzma_ret(ret, LZMA_FORMAT_ERROR);
+	
+	const char *err_msg = lzma_get_error_message(&strm);
+	assert_true(err_msg != NULL);
+	
+	lzma_end(&strm);
+}
+
+
+static void
+test_error_message_none_on_success(void)
+{
+	// Test that error message is NULL after successful operation
+	lzma_stream strm = LZMA_STREAM_INIT;
+	
+	// Initialize an encoder
+	lzma_ret ret = lzma_easy_encoder(&strm, LZMA_PRESET_DEFAULT, LZMA_CHECK_CRC64);
+	assert_lzma_ret(ret, LZMA_OK);
+
+	// Set up valid input/output buffers
+	uint8_t input_data[] = "Hello";
+	uint8_t output_buffer[100];
+	
+	strm.next_in = input_data;
+	strm.avail_in = sizeof(input_data) - 1;
+	strm.next_out = output_buffer;
+	strm.avail_out = sizeof(output_buffer);
+
+	ret = lzma_code(&strm, LZMA_RUN);
+	// This should return LZMA_OK
+	assert_lzma_ret(ret, LZMA_OK);
+	
+	// Error message should be NULL for successful operations
+	const char *err_msg = lzma_get_error_message(&strm);
+	assert_true(err_msg == NULL);
+	
+	lzma_end(&strm);
+}
+
+
+static void
+test_error_message_null_stream(void)
+{
+	// Test that lzma_get_error_message handles NULL stream
+	const char *err_msg = lzma_get_error_message(NULL);
+	assert_true(err_msg == NULL);
+}
+
+
+static void
+test_error_message_cleared_after_end(void)
+{
+	// Test that error message is cleared after lzma_end
+	lzma_stream strm = LZMA_STREAM_INIT;
+	
+	// Initialize an encoder
+	lzma_ret ret = lzma_easy_encoder(&strm, LZMA_PRESET_DEFAULT, LZMA_CHECK_CRC64);
+	assert_lzma_ret(ret, LZMA_OK);
+
+	// Cause an error
+	strm.next_out = NULL;
+	strm.avail_out = 100;
+	
+	ret = lzma_code(&strm, LZMA_RUN);
+	assert_lzma_ret(ret, LZMA_PROG_ERROR);
+	
+	// Error message should be set
+	const char *err_msg = lzma_get_error_message(&strm);
+	assert_true(err_msg != NULL);
+	
+	// After lzma_end, the error message should be cleared
+	lzma_end(&strm);
+	err_msg = lzma_get_error_message(&strm);
+	assert_true(err_msg == NULL);
+}
+
+
+extern int
+main(int argc, char *argv[])
+{
+	tuktest_start(argc, argv);
+	tuktest_run(test_error_message_prog_error);
+	tuktest_run(test_error_message_format_error);
+	tuktest_run(test_error_message_none_on_success);
+	tuktest_run(test_error_message_null_stream);
+	tuktest_run(test_error_message_cleared_after_end);
+	tuktest_end();
+
+	return 0;
+}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -63,6 +63,7 @@ if(BUILD_TESTING)
         test_memlimit
         test_stream_flags
         test_vli
+        test_error_messages
     )
 
     # MicroLZMA encoder is needed for both encoder and decoder tests.


### PR DESCRIPTION
This change adds human-readable error messages for selected lzma_code() return values, making liblzma errors easier to understand and diagnose. A new public helper function, lzma_get_error_message(), lets applications retrieve the message associated with the most recent lzma_code() failure. The implementation includes support for common errors such as out-of-memory, data corruption, unsupported options, and programming errors, while returning NULL when no message is available. The new behavior is covered by tests and shown in the example programs, and the documentation has been updated accordingly.

As a first contribution, I’d appreciate any feedback on the code quality, naming, or implementation style to help align this change with the project’s standards.