### PR TITLE
xz: Mask the multiplier suffix in str_to_uint64 error message

### DIFF
--- a/src/xz/util.c
+++ b/src/xz/util.c
@@ -154,7 +154,7 @@ str_to_uint64(const char *name, const char *value, uint64_t min, uint64_t max)
 
 		if (multiplier == 0) {
 			message(V_ERROR, _("%s: Invalid multiplier suffix"),
-					value - 1);
+					tuklib_mask_nonprint(value - 1));
 			message_fatal(_("Valid suffixes are 'KiB' (2^10), "
 					"'MiB' (2^20), and 'GiB' (2^30)."));
 		}


### PR DESCRIPTION
The "Invalid multiplier suffix" error in str_to_uint64 prints the user-supplied suffix directly, while the other error path in the same function masks it. A suffix containing control bytes therefore reaches the terminal unescaped. Commit 7e7bb6c masked the sibling message a few lines up but missed this one, so route it through tuklib_mask_nonprint too.