### PR TITLE
xz: Copy --files/--files0 path so it outlives XZ_OPT/XZ_DEFAULTS parsing

### DIFF
--- a/src/xz/args.c
+++ b/src/xz/args.c
@@ -641,15 +641,20 @@ parse_real(args_info *args, int argc, char **argv)
 				args->files_name = stdin_filename;
 				args->files_file = stdin;
 			} else {
-				args->files_name = optarg;
-				args->files_file = fopen(optarg,
+				// optarg may point into a buffer that doesn't
+				// outlive parse_real() (parse_environment()
+				// frees its copy of the env string when it
+				// returns), so keep our own copy.
+				args->files_name = xstrdup(optarg);
+				args->files_file = fopen(args->files_name,
 						c == OPT_FILES ? "r" : "rb");
 				if (args->files_file == NULL)
 					// TRANSLATORS: This is a translatable
 					// string because French needs a space
 					// before the colon ("%s : %s").
 					message_fatal(_("%s: %s"),
-						tuklib_mask_nonprint(optarg),
+						tuklib_mask_nonprint(
+							args->files_name),
 						strerror(errno));
 			}
 


### PR DESCRIPTION
Noticed args->files_name is set straight from optarg, but when the option comes from XZ_OPT or XZ_DEFAULTS, parse_environment() frees the env buffer optarg points into. Later reads through args->files_name (e.g. the 'Unexpected end of input' / null-character paths in read_name()) hit freed memory.

Trigger: `printf foo.txt > files.lst; XZ_OPT=--files=files.lst xz` prints `xz: ?: Unexpected end of input` instead of `xz: files.lst: ...` because tuklib_mask_nonprint walks the now-overwritten bytes. xstrdup the path so args->files_name owns it.