### PR TITLE
xz: mask non-printable chars in the invalid multiplier suffix message

### DIFF
--- a/src/xz/util.c
+++ b/src/xz/util.c
@@ -154,7 +154,7 @@ str_to_uint64(const char *name, const char *value, uint64_t min, uint64_t max)
 
 		if (multiplier == 0) {
 			message(V_ERROR, _("%s: Invalid multiplier suffix"),
-					value - 1);
+					tuklib_mask_nonprint(value - 1));
 			message_fatal(_("Valid suffixes are 'KiB' (2^10), "
 					"'MiB' (2^20), and 'GiB' (2^30)."));
 		}


### PR DESCRIPTION
str_to_uint64() masks non-printable bytes in the "not a non-negative decimal integer" message (commit 7e7bb6c) but the "Invalid multiplier suffix" message a few lines down still prints the raw suffix. A leading digit routes parsing into that branch, so `--block-size=5$'\e[2J'` (or the same via XZ_OPT) sends control/escape bytes straight to the terminal. Mask it the same way.