### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       ########################
       # Install Dependencies #
@@ -164,7 +164,7 @@ jobs:
         run: ./build-aux/ci_build.bash -b ${{ matrix.build_system }} -d small -p test -n small
 
       # Attempt to upload the test logs as artifacts if any step has failed
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() }}
         with:
           name: ${{ matrix.os }} ${{ matrix.build_system }} Test Logs

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@10d372d86bc3ca5d662790345c2f4e146367e4c4 # master
       with:
         oss-fuzz-project-name: 'xz'
         # The language must match the one in project.yaml in OSS-Fuzz:
@@ -38,7 +38,7 @@ jobs:
         sanitizer: ${{ matrix.sanitizer }}
 
     - name: Run Fuzzers (${{ matrix.sanitizer }})
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@10d372d86bc3ca5d662790345c2f4e146367e4c4 # master
       with:
         oss-fuzz-project-name: 'xz'
         language: c++
@@ -48,7 +48,7 @@ jobs:
         report-ooms: true
 
     - name: Upload Crash
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure() && steps.build.outcome == 'success'
       with:
         name: ${{ matrix.sanitizer }}-artifacts

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ jobs:
   coverity:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/dragonflybsd.yml
+++ b/.github/workflows/dragonflybsd.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     name: DragonFly BSD
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Test in DragonFly BSD
         id: test

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -34,7 +34,7 @@ jobs:
     name: FreeBSD
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Test in FreeBSD
         uses: vmactions/freebsd-vm@4807432c7cab1c3f97688665332c0b932062d31f #v1.4.3

--- a/.github/workflows/haiku.yml
+++ b/.github/workflows/haiku.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     name: Haiku
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Test in Haiku
         id: test

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Configure Win32
         run: >

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -78,7 +78,7 @@ jobs:
         # text file and will not match the output from xzgrep.
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: CMake (full, shared)
         run: |
@@ -137,7 +137,7 @@ jobs:
           make -j"$(nproc)" check
 
       # Upload the test logs as artifacts if any step has failed.
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: test-logs-${{ matrix.sys }}

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     name: NetBSD
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Test in NetBSD
         id: test

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     name: OpenBSD
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Test in OpenBSD
         uses: vmactions/openbsd-vm@3fafb45f2e2e696249c583835939323fe1c3448c #v1.3.7

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     name: Solaris
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Test in Solaris
         uses: vmactions/solaris-vm@0a231b94365d1911cf62097ef342f6b30d95598f #v1.3.2


### PR DESCRIPTION
Several workflow files reference GitHub Actions via mutable version tags (e.g. `@v4`, `@v3`) instead of full commit SHAs. This is a supply chain risk — a compromised action repository could silently alter CI behavior.

This PR pins each action to the exact commit SHA corresponding to the version tag, making the dependency immutable and auditable.

Recommended by [GitHub security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [OpenSSF Scorecard](https://securityscorecards.dev/).