### PR TITLE
xzdiff: run the option escaping under LC_ALL=C

### DIFF
--- a/src/scripts/xzdiff.in
+++ b/src/scripts/xzdiff.in
@@ -56,7 +56,7 @@ while :; do
     --h*) printf '%s\n' "$usage" || exit 2; exit;;
     --v*) printf '%s\n' "$version" || exit 2; exit;;
     --) shift; break;;
-    -*\'*) cmp="$cmp '"`printf '%sX\n' "$1" | sed "$escape"`;;
+    -*\'*) cmp="$cmp '"`printf '%sX\n' "$1" | LC_ALL=C sed "$escape"`;;
     -?*) cmp="$cmp '$1'";;
     *) break;;
   esac


### PR DESCRIPTION
`xzdiff` escapes option arguments with `sed "$escape"` in the caller's locale before appending them to `$cmp`, which is later run through `eval`. the sibling `xzgrep` already wraps the same escape in `LC_ALL=C sed`. in a multibyte locale, an option arg holding bytes that are invalid there makes sed misbehave (BSD sed aborts with `RE error: illegal byte sequence`, GNU sed can mis-segment), so the `$s/X$/'/` rule doesn't fire and `$cmp` ends with an unbalanced quote. the malformed string then reaches `eval`: `LC_ALL=zh_CN.GB18030 xzcmp "-i='$(printf '\\x81')" a.xz b.xz` gives `eval: unexpected EOF while looking for matching '`.

the escape is byte-oriented because the shell treats `'` as a byte, so it has to run in the C locale to match how the result is consumed. forcing `LC_ALL=C` on the sed keeps the escaping byte-exact regardless of the user's locale, same as `xzgrep` already does.