### PR TITLE
Harden Coverity workflow permissions

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [coverity_scan]
 
+permissions:
+  contents: read
+
 jobs:
   coverity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This tightens the GitHub Actions Coverity workflow permissions without changing the scan behavior.

The workflow only needs repository read access for checkout and build execution, so this sets the default `GITHUB_TOKEN` permission to `contents: read`.

I verified the workflow YAML still parses, `git diff --check` passes, and `zizmor` no longer reports the previous excessive-permissions finding. The remaining finding is an action pinning warning, which I left out of this focused change.
