### PR TITLE
xz: free files_name when closing the --files or --files0 file

### DIFF
--- a/src/xz/main.c
+++ b/src/xz/main.c
@@ -335,8 +335,10 @@ main(int argc, char **argv)
 			run(name);
 		}
 
-		if (args.files_name != stdin_filename)
+		if (args.files_name != stdin_filename) {
 			(void)fclose(args.files_file);
+			free((void *)args.files_name);
+		}
 	}
 
 #ifdef HAVE_DECODERS


### PR DESCRIPTION
Commit 1aab7e9c changed `args->files_name = optarg` to
`args->files_name = xstrdup(optarg)` to fix a use-after-free when
`--files` or `--files0` is given via `XZ_OPT` or `XZ_DEFAULTS`. The
fix is correct, but the corresponding cleanup in `main()` was not
updated to free the duplicated string.

Before 1aab7e9c, `files_name` was either `stdin_filename` (a static
string) or a pointer into `argv[]` or the env string, so nothing
needed freeing. After that commit, it is always `xstrdup()`'d when
non-NULL and not `stdin_filename`, in both the env-var path and the
direct command-line path.

The fix adds a `free()` next to the existing `fclose()` in `main()`,
which already guards against the `stdin_filename` case with the same
check. The change is one line in the place that already handles this
cleanup.

This shows up as a reachable allocation under Valgrind when building
with `--enable-debug` and running `xz` with `--files=FILE`.

## Testing

Verified by code inspection. The leak can be reproduced with:

```sh
./configure --enable-debug
make
echo foo.xz > filelist.txt
valgrind --leak-check=full src/xz/xz --files=filelist.txt -l 2>&1 | grep files_name
```

Without this fix, Valgrind reports a reachable block from the
`xstrdup()` call in `parse_real()`. With this fix it does not.