### PR TITLE
liblzma: Preserve check statistics in lzma_index_dup()

### DIFF
--- a/src/liblzma/common/index.c
+++ b/src/liblzma/common/index.c
@@ -974,6 +974,7 @@ lzma_index_dup(const lzma_index *src, const lzma_allocator *allocator)
 	dest->total_size = src->total_size;
 	dest->record_count = src->record_count;
 	dest->index_list_size = src->index_list_size;
+	dest->checks = src->checks;
 
 	// Copy the Streams and the groups in them.
 	const index_stream *srcstream

--- a/tests/test_index.c
+++ b/tests/test_index.c
@@ -1319,6 +1319,13 @@ test_lzma_index_dup(void)
 	lzma_index *idx = lzma_index_init(NULL);
 	assert_true(idx != NULL);
 
+	lzma_stream_flags flags = {
+		.version = 0,
+		.backward_size = LZMA_BACKWARD_SIZE_MIN,
+		.check = LZMA_CHECK_CRC32,
+	};
+	assert_lzma_ret(lzma_index_stream_flags(idx, &flags), LZMA_OK);
+
 	// Test for the bug fix 21515d79d778b8730a434f151b07202d52a04611:
 	// liblzma: Fix lzma_index_dup() for empty Streams.
 	assert_lzma_ret(lzma_index_stream_padding(idx, 4), LZMA_OK);
@@ -1343,10 +1350,16 @@ test_lzma_index_dup(void)
 	lzma_index *second = lzma_index_init(NULL);
 	assert_true(second != NULL);
 
+	flags.check = LZMA_CHECK_CRC64;
+	assert_lzma_ret(lzma_index_stream_flags(second, &flags), LZMA_OK);
+
 	assert_lzma_ret(lzma_index_stream_padding(second, 16), LZMA_OK);
 
 	lzma_index *third = lzma_index_init(NULL);
 	assert_true(third != NULL);
+
+	flags.check = LZMA_CHECK_SHA256;
+	assert_lzma_ret(lzma_index_stream_flags(third, &flags), LZMA_OK);
 
 	assert_lzma_ret(lzma_index_append(third, NULL,
 			UNPADDED_SIZE_MIN * 10, 40), LZMA_OK);
@@ -1361,6 +1374,7 @@ test_lzma_index_dup(void)
 	copy = lzma_index_dup(idx, NULL);
 	assert_true(copy != NULL);
 	assert_true(index_is_equal(idx, copy));
+	assert_uint_eq(lzma_index_checks(copy), lzma_index_checks(idx));
 
 	lzma_index_end(copy, NULL);
 	lzma_index_end(idx, NULL);


### PR DESCRIPTION
## Summary

- copy the cached integrity Check mask when duplicating an `lzma_index`
- add regression coverage for a three-Stream Index using CRC32, CRC64, and SHA-256

## Problem

`index_dup_stream()` preserves each Stream's flags, but `lzma_index_dup()` left the aggregate `checks` cache at its zero-initialized value. `lzma_index_checks()` therefore reported only the final Stream's Check type for a duplicated multi-Stream Index.

Before the fix, the regression test reports `1024` (SHA-256 only) instead of `1042` (CRC32, CRC64, and SHA-256). Copying `src->checks` preserves the same statistics as the source Index.

## Testing

- `ctest --test-dir /tmp/xz-build-normal-20260728-a -R '^test_index$' --output-on-failure`
- `ctest --test-dir /tmp/xz-build-normal-20260728-a --output-on-failure -j2` (20/20 passed)