### PR TITLE
Fix failing test cases on Windows

### DIFF
--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -93,6 +93,16 @@ if(BUILD_TESTING)
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/tests_bin"
         )
 
+        # Copy liblzma.dll to the test directory on Windows if building shared
+        # libs because it has to be in the same directory as the test binaries.
+        if(WIN32 AND BUILD_SHARED_LIBS)
+            add_custom_command(TARGET "${TEST}" POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    $<TARGET_FILE:liblzma>
+                    $<TARGET_FILE_DIR:${TEST}>
+            )
+        endif()
+
         add_test(NAME "${TEST}"
                  COMMAND "${CMAKE_CURRENT_BINARY_DIR}/tests_bin/${TEST}"
         )


### PR DESCRIPTION
This PR fixes failing test cases when running tests on Windows.
The issue only occurs when building xz using cmake, with option `-DBUILD_SHARED_LIBS=ON`. The test binaries cannot find the `liblzma.dll` file, resulting in a fail of the test cases.

To fix this issue, this PR introduces a copy command, which copies the `libzma.dll` file to the same directory as the test binaries. 