### PR TITLE
xz: Avoid integer overflow in --list totals

### DIFF
--- a/src/xz/list.c
+++ b/src/xz/list.c
@@ -213,6 +213,11 @@ static struct {
 	bool all_have_sizes;
 } totals = { 0, 0, 0, 0, 0, 0, 0, 0, 50000002, true };
 
+/// If calculating the totals overflows, don't print a partial totals line.
+/// In particular, --robot output may be used by scripts that expect the
+/// numeric fields to be trustworthy.
+static bool totals_overflow = false;
+
 
 /// Initialize colon_strs_fw[].
 static void
@@ -1142,12 +1147,33 @@ print_info_robot(xz_file_info *xfi, file_pair *pair)
 static void
 update_totals(const xz_file_info *xfi)
 {
-	// TODO: Integer overflow checks
+	if (totals_overflow)
+		return;
+
+	const uint64_t streams = lzma_index_stream_count(xfi->idx);
+	const uint64_t blocks = lzma_index_block_count(xfi->idx);
+	const uint64_t compressed_size = lzma_index_file_size(xfi->idx);
+	const uint64_t uncompressed_size
+			= lzma_index_uncompressed_size(xfi->idx);
+
+	if (totals.files == UINT64_MAX
+			|| UINT64_MAX - totals.streams < streams
+			|| UINT64_MAX - totals.blocks < blocks
+			|| UINT64_MAX - totals.compressed_size < compressed_size
+			|| UINT64_MAX - totals.uncompressed_size
+				< uncompressed_size
+			|| UINT64_MAX - totals.stream_padding
+				< xfi->stream_padding) {
+		message_error(_("The totals exceed the supported 64-bit range"));
+		totals_overflow = true;
+		return;
+	}
+
 	++totals.files;
-	totals.streams += lzma_index_stream_count(xfi->idx);
-	totals.blocks += lzma_index_block_count(xfi->idx);
-	totals.compressed_size += lzma_index_file_size(xfi->idx);
-	totals.uncompressed_size += lzma_index_uncompressed_size(xfi->idx);
+	totals.streams += streams;
+	totals.blocks += blocks;
+	totals.compressed_size += compressed_size;
+	totals.uncompressed_size += uncompressed_size;
 	totals.stream_padding += xfi->stream_padding;
 	totals.checks |= lzma_index_checks(xfi->idx);
 
@@ -1271,6 +1297,9 @@ print_totals_robot(void)
 extern void
 list_totals(void)
 {
+	if (totals_overflow)
+		return;
+
 	if (opt_robot) {
 		// Always print totals in --robot mode. It can be convenient
 		// in some cases and doesn't complicate usage of the

--- a/src/xz/list.c
+++ b/src/xz/list.c
@@ -213,11 +213,6 @@ static struct {
 	bool all_have_sizes;
 } totals = { 0, 0, 0, 0, 0, 0, 0, 0, 50000002, true };
 
-/// If calculating the totals overflows, don't print a partial totals line.
-/// In particular, --robot output may be used by scripts that expect the
-/// numeric fields to be trustworthy.
-static bool totals_overflow = false;
-
 
 /// Initialize colon_strs_fw[].
 static void
@@ -1147,9 +1142,6 @@ print_info_robot(xz_file_info *xfi, file_pair *pair)
 static void
 update_totals(const xz_file_info *xfi)
 {
-	if (totals_overflow)
-		return;
-
 	const uint64_t streams = lzma_index_stream_count(xfi->idx);
 	const uint64_t blocks = lzma_index_block_count(xfi->idx);
 	const uint64_t compressed_size = lzma_index_file_size(xfi->idx);
@@ -1163,11 +1155,8 @@ update_totals(const xz_file_info *xfi)
 			|| UINT64_MAX - totals.uncompressed_size
 				< uncompressed_size
 			|| UINT64_MAX - totals.stream_padding
-				< xfi->stream_padding) {
-		message_error(_("The totals exceed the supported 64-bit range"));
-		totals_overflow = true;
-		return;
-	}
+				< xfi->stream_padding)
+		message_fatal(_("The totals exceed the supported 64-bit range"));
 
 	++totals.files;
 	totals.streams += streams;
@@ -1297,9 +1286,6 @@ print_totals_robot(void)
 extern void
 list_totals(void)
 {
-	if (totals_overflow)
-		return;
-
 	if (opt_robot) {
 		// Always print totals in --robot mode. It can be convenient
 		// in some cases and doesn't complicate usage of the

--- a/tests/test_files.sh
+++ b/tests/test_files.sh
@@ -130,6 +130,47 @@ if test -n "$XZ" && "$XZ" -l "$I" > /dev/null 2>&1; then
 	exit 1
 fi
 
+# Each of these two files has a valid Index for list mode. The first claims
+# LZMA_VLI_MAX bytes and the second claims two bytes. Listing the first file
+# twice and then the second used to wrap the total uncompressed size from
+# exactly 2^64 to zero. The fourth argument verifies that xz exits immediately
+# when the overflow is detected instead of processing more files.
+if test -n "$XZ"; then
+	LIST_MAX=list-overflow-max.xz
+	LIST_TWO=list-overflow-two.xz
+	LIST_OUTPUT=list-overflow-output
+	trap 'rm -f "$LIST_MAX" "$LIST_TWO" "$LIST_OUTPUT"' 0
+
+	printf '%b' \
+		'\375\067\172\130\132\000\000\000\377\022\331\101\000\000\000\000' \
+		'\000\000\000\000\000\001\005\377\377\377\377\377\377\377\377\177' \
+		'\365\135\343\274\015\323\126\067\003\000\000\000\000\000\131\132' \
+		> "$LIST_MAX" \
+		|| exit 1
+	printf '%b' \
+		'\375\067\172\130\132\000\000\000\377\022\331\101\000\000\000\000' \
+		'\000\000\000\000\000\001\005\002\102\040\377\263\006\162\236\172' \
+		'\001\000\000\000\000\000\131\132' \
+		> "$LIST_TWO" \
+		|| exit 1
+
+	if "$XZ" --robot -l "$LIST_MAX" "$LIST_MAX" "$LIST_TWO" \
+			"$LIST_TWO" > "$LIST_OUTPUT" 2> /dev/null; then
+		echo "xz -l accepted totals exceeding the 64-bit range"
+		exit 1
+	fi
+
+	if grep '^totals' "$LIST_OUTPUT" > /dev/null; then
+		echo "xz -l printed wrapped totals exceeding the 64-bit range"
+		exit 1
+	fi
+
+	if test "$(grep -c '^name	' "$LIST_OUTPUT")" -ne 3; then
+		echo "xz -l continued processing files after a totals overflow"
+		exit 1
+	fi
+fi
+
 for I in "$srcdir"/files/unsupported-*.xz
 do
 	# Test these only with xz as unsupported-check.xz will exit

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -210,10 +210,10 @@ if(BUILD_TESTING)
     # test_files.sh decompresses files that use different filters and
     # check types so run it only if support for all of them has been enabled.
     if(UNIX AND HAVE_ALL_DECODERS AND HAVE_ALL_CHECKS AND XZ_LZIP_DECODER)
-        # test_files.sh doesn't make any temporary files but it
-        # must not be run at the top-level build directory because
-        # it checks if ../config.h exists. We don't want to read
-        # files outside the build directory!
+        # test_files.sh must not be run at the top-level build directory
+        # because it checks if ../config.h exists. We don't want to read files
+        # outside the build directory! It also creates its temporary files in
+        # its working directory.
         file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files")
 
         add_test(NAME test_files.sh


### PR DESCRIPTION
`xz --list` reads the per-file sizes from the Index without decompressing Blocks. Each value is limited to `LZMA_VLI_MAX`, but `update_totals()` combines multiple files in `uint64_t` fields without checking the additions. Two maximum Uncompressed Size values followed by 2 therefore wrap the robot total from `2^64` to zero.

Minimal 136-byte reproducer set:

```sh
printf %s '/Td6WFoAAAD/EtlBAAAAAAAAAAAAAQX//////////3/1XeO8DdNWNwMAAAAAAFla' | base64 -d > max1.xz
cp max1.xz max2.xz
printf %s '/Td6WFoAAAD/EtlBAAAAAAAAAAAAAQUCQiD/swZynnoBAAAAAABZWg==' | base64 -d > two.xz
xz --robot --list max1.xz max2.xz two.xz
```

Current `master` (`c8b8ab2ef1eb0a0217ad2027d7f5d242ceb944d3`) ends with:

```text
totals 3 3 136 0 --- None 0 3
```

(The actual output is tab-separated.) A script using the documented robot total as a size or quota gate can consequently treat attacker-controlled metadata describing `2^64` bytes as zero.

This patch checks every numeric accumulation before modifying the totals. On overflow, xz exits with status 1, reports `The totals exceed the supported 64-bit range`, and omits the misleading partial `totals` line while preserving the individual file rows.

Validation performed:

- Release build completed with CMake/Ninja.
- All 20 CTest tests passed.
- `git diff --check` passed.
- Current open and closed issues/PRs were searched for the same `list.c` totals overflow; no matching report was found.

Discovery note: a time-boxed local AI-assisted review pointed to the existing integer-overflow TODO. I independently constructed and validated the binary reproducer against the exact upstream commit, checked for duplicates, implemented the patch, and ran the full test suite.